### PR TITLE
remove authors file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,0 @@
-This is the official list of Gremlins authors for copyright purposes.
-
-Davide Petilli <davide.petilli@gmail.com>


### PR DESCRIPTION
If Google can remove it, we can as well. Git commits are
enough to attribute copyright.
