### PR TITLE
feat: make mutant types switchable

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,4 +1,4 @@
 unleash:
   threshold:
-    efficacy: 83
-    mutant-coverage: 84
+    efficacy: 80
+    mutant-coverage: 90

--- a/cmd/gremlins.go
+++ b/cmd/gremlins.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -57,12 +58,16 @@ func (gc gremlinsCmd) execute() error {
 }
 
 func newRootCmd(version string) (*gremlinsCmd, error) {
+	if version == "" {
+		return nil, errors.New("expected a version string")
+	}
+
 	cmd := &cobra.Command{
 		Hidden:        true,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Use:           "gremlins <command> [arguments]",
-		Short: `Gremlins is a mutation testing tool for Go projects, made with love by go-gremlins 
+		Short: `Gremlins is a mutation testing tool for Go projects, made with love by k3rn31 
 and friends.
 `,
 		Version: version,

--- a/cmd/gremlins_test.go
+++ b/cmd/gremlins_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestGremlins(t *testing.T) {
+	c, err := newRootCmd("1.2.3")
+	if err != nil {
+		t.Fatal("newRootCmd should not fail")
+	}
+	_ = c.execute()
+	cmd := c.cmd
+
+	if cmd.Version != "1.2.3" {
+		t.Errorf("expected %q, got %q", "1.2.3", cmd.Version)
+	}
+
+	cfgFile := cmd.Flag("config")
+	if cfgFile == nil {
+		t.Fatal("expected to have a config flag")
+	}
+	if cfgFile.Value.Type() != "string" {
+		t.Errorf("expected value type to be 'string', got %v", cfgFile.Value.Type())
+	}
+	if cfgFile.DefValue != "" {
+		t.Errorf("expected default value to be empty, got %v", cfgFile.DefValue)
+	}
+}
+
+func TestExecute(t *testing.T) {
+	t.Run("should not fail", func(t *testing.T) {
+		err := Execute("1.2.3")
+		if err != nil {
+			t.Errorf("execute should not fail")
+		}
+	})
+
+	t.Run("should fail if version is not set", func(t *testing.T) {
+		err := Execute("")
+		if err == nil {
+			t.Errorf("expected failure")
+		}
+
+	})
+}

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package flags
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// Flag is the internal representation of a command flag. It is used to set
+// flags in a more generic way.
+type Flag struct {
+	Name      string
+	CfgKey    string
+	Shorthand string
+	DefaultV  any
+	Usage     string
+}
+
+// Set is a "generic" function used to set flags on cobra.Command and bind
+// them to viper.Viper.
+func Set(cmd *cobra.Command, flag Flag) error {
+	flags := cmd.Flags()
+	switch dv := flag.DefaultV.(type) {
+	// TODO: add a case for all the supported types
+	case bool:
+		setBool(flag, flags, dv)
+	case string:
+		setString(flag, flags, dv)
+	case float64:
+		setFloat64(flag, flags, dv)
+	}
+	err := viper.BindPFlag(flag.CfgKey, flags.Lookup(flag.Name))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setFloat64(flag Flag, flags *pflag.FlagSet, dv float64) {
+	if flag.Shorthand != "" {
+		flags.Float64P(flag.Name, flag.Shorthand, dv, flag.Usage)
+	} else {
+		flags.Float64(flag.Name, dv, flag.Usage)
+	}
+}
+
+func setString(flag Flag, flags *pflag.FlagSet, dv string) {
+	if flag.Shorthand != "" {
+		flags.StringP(flag.Name, flag.Shorthand, dv, flag.Usage)
+	} else {
+		flags.String(flag.Name, dv, flag.Usage)
+	}
+}
+
+func setBool(flag Flag, flags *pflag.FlagSet, dv bool) {
+	if flag.Shorthand != "" {
+		flags.BoolP(flag.Name, flag.Shorthand, dv, flag.Usage)
+	} else {
+		flags.Bool(flag.Name, dv, flag.Usage)
+	}
+}

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type unsupportedType int
+
+func TestSet(t *testing.T) {
+	testCases := []struct {
+		flag        Flag
+		expectError bool
+	}{
+		{
+			flag: Flag{
+				Name:      "bool-flag-no-sh",
+				CfgKey:    "test.cfg",
+				Shorthand: "",
+				DefaultV:  true,
+				Usage:     "test usage",
+			},
+		},
+		{
+			flag: Flag{
+				Name:      "bool-flag-sh",
+				CfgKey:    "test.cfg",
+				Shorthand: "t",
+				DefaultV:  true,
+				Usage:     "test usage",
+			},
+		},
+
+		{
+			flag: Flag{
+				Name:      "string-flag-no-sh",
+				CfgKey:    "test.cfg",
+				Shorthand: "",
+				DefaultV:  "test",
+				Usage:     "test usage",
+			},
+		},
+		{
+			flag: Flag{
+				Name:      "string-flag-sh",
+				CfgKey:    "test.cfg",
+				Shorthand: "t",
+				DefaultV:  "test",
+				Usage:     "test usage",
+			},
+		},
+
+		{
+			flag: Flag{
+				Name:      "float64-flag-no-sh",
+				CfgKey:    "test.cfg",
+				Shorthand: "",
+				DefaultV:  float64(0),
+				Usage:     "test usage",
+			},
+		},
+		{
+			flag: Flag{
+				Name:      "float64-flag-sh",
+				CfgKey:    "test.cfg",
+				Shorthand: "t",
+				DefaultV:  float64(0),
+				Usage:     "test usage",
+			},
+		},
+		{
+			flag: Flag{
+				Name:      "not-supported-type",
+				CfgKey:    "test.cfg",
+				Shorthand: "t",
+				DefaultV:  unsupportedType(0),
+				Usage:     "test usage",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.flag.Name, func(t *testing.T) {
+			defer viper.Reset()
+
+			cmd := &cobra.Command{}
+
+			err := Set(cmd, tc.flag)
+			if (tc.expectError && err == nil) || (!tc.expectError && err != nil) {
+				t.Fatal("error not expected")
+			}
+		})
+	}
+}

--- a/cmd/unleash_test.go
+++ b/cmd/unleash_test.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-gremlins/gremlins/configuration"
+	"github.com/go-gremlins/gremlins/pkg/mutant"
+)
+
+func TestUnleash(t *testing.T) {
+	c, err := newUnleashCmd()
+	if err != nil {
+		t.Fatal("newUnleashCmd should no fail")
+	}
+	cmd := c.cmd
+
+	if cmd.Name() != "unleash" {
+		t.Errorf("expected 'unleash', got %q", cmd.Name())
+	}
+
+	flags := cmd.Flags()
+
+	// Test for dry-run
+	f := flags.Lookup("dry-run")
+	if f.Value.Type() != "bool" {
+		t.Errorf("expected 'dry-run' to be a 'bool', got %q", f.Value.Type())
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected 'dry-run' have default 'false', got %q", f.DefValue)
+	}
+
+	// Test for tags
+	f = flags.Lookup("tags")
+	if f.Value.Type() != "string" {
+		t.Errorf("expected 'tags' to be a 'string', got %q", f.Value.Type())
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected 'tags' not to be set by default, got %q", f.DefValue)
+	}
+
+	// test threshold-efficacy
+	f = flags.Lookup("threshold-efficacy")
+	if f.Value.Type() != "float64" {
+		t.Errorf("expected 'threshold-efficacy' to be a 'float64', got %q", f.Value.Type())
+	}
+	if f.DefValue != "0" {
+		t.Errorf("expected 'threshold-efficacy' have default '0', got %q", f.DefValue)
+	}
+
+	// test threshold-mcover
+	f = flags.Lookup("threshold-mcover")
+	if f.Value.Type() != "float64" {
+		t.Errorf("expected 'threshold-mcover' to be a 'float64', got %q", f.Value.Type())
+	}
+	if f.DefValue != "0" {
+		t.Errorf("expected 'threshold-mcover' have default '0', got %q", f.DefValue)
+	}
+
+	// test for MutantTypes flags
+	for _, mt := range mutant.MutantTypes {
+		s := strings.ToLower(mt.String())
+		mtf := flags.Lookup(s)
+		if mtf == nil {
+			t.Errorf("expected to have flag for mutant type: %s", mt)
+
+			continue
+		}
+
+		if mtf.Value.Type() != "bool" {
+			t.Errorf("expected %q to be a %q, got %q", s, "bool", mtf.Value.Type())
+		}
+		wantDef := fmt.Sprintf("%v", configuration.IsDefaultEnabled(mt))
+		if mtf.DefValue != wantDef {
+			t.Errorf("expected %q have default %q, got %q", s, wantDef, mtf.DefValue)
+		}
+	}
+}
+
+func TestChangePath(t *testing.T) {
+	const wantCalledDir = "aDir"
+
+	t.Run("when passed a dir, it changes to it and returns '.'", func(t *testing.T) {
+		var calledDir string
+		chdir := func(dir string) error {
+			calledDir = dir
+
+			return nil
+		}
+		getwd := func() (string, error) {
+			return "test/dir", nil
+		}
+		args := []string{wantCalledDir}
+
+		p, wd, _ := changePath(args, chdir, getwd)
+
+		if calledDir != wantCalledDir {
+			t.Errorf("expected %q, got %q", wantCalledDir, calledDir)
+		}
+		if p != "." {
+			t.Errorf("expected '.', got %q", p)
+		}
+		if wd != "test/dir" {
+			t.Errorf("expected 'test/dir', got %s", wd)
+		}
+	})
+
+	t.Run("when Chdir returns error, it returns error", func(t *testing.T) {
+		chdir := func(dir string) error { return errors.New("test error") }
+		getwd := func() (string, error) { return "", nil }
+		args := []string{wantCalledDir}
+
+		_, _, err := changePath(args, chdir, getwd)
+		if err == nil {
+			t.Errorf("expected an error")
+		}
+	})
+
+	t.Run("when Getwd returns error, it returns error", func(t *testing.T) {
+		chdir := func(dir string) error { return nil }
+		getwd := func() (string, error) { return "", errors.New("test error") }
+		args := []string{wantCalledDir}
+
+		_, _, err := changePath(args, chdir, getwd)
+		if err == nil {
+			t.Errorf("expected an error")
+		}
+	})
+}
+
+func TestRunUnleashCmd(t *testing.T) {
+	t.Run("should fail without go.mod", func(t *testing.T) {
+		pwd, _ := os.Getwd()
+		args := []string{pwd}
+		err := runUnleash(nil, args)
+		if err == nil {
+			t.Fatal("runUnleashCmd should fail")
+		}
+	})
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -17,6 +17,7 @@
 package configuration
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,6 +25,8 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
+
+	"github.com/go-gremlins/gremlins/pkg/mutant"
 )
 
 // This is the list of the keys available in config files and ad flags.
@@ -75,6 +78,21 @@ func Init(cPaths []string) error {
 	_ = viper.ReadInConfig() // ignoring error if file not present
 
 	return nil
+}
+
+// MutantTypeEnabledKey returns the configuration key for a mutant.
+// The generated key will have the format 'mutants.mutant-name.enabled",
+// which corresponds to the Yaml:
+//
+// 		mutants:
+//  		mutant-name:
+//  			enabled: [bool]
+func MutantTypeEnabledKey(mt mutant.Type) string {
+	m := mt.String()
+	m = strings.ReplaceAll(m, "_", "-")
+	m = strings.ToLower(m)
+
+	return fmt.Sprintf("mutants.%s.enabled", m)
 }
 
 func isSpecificFile(cPaths []string) bool {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
+
+	"github.com/go-gremlins/gremlins/pkg/mutant"
 )
 
 type envEntry struct {
@@ -160,4 +162,15 @@ func TestConfigPaths(t *testing.T) {
 			t.Errorf(cmp.Diff(got, want))
 		}
 	})
+}
+
+func TestGeneratesMutantTypeEnabledKey(t *testing.T) {
+	mt := mutant.ArithmeticBase
+	want := "mutants.arithmetic-base.enabled"
+
+	got := MutantTypeEnabledKey(mt)
+
+	if got != want {
+		t.Errorf("expected %q, got %q", mt, want)
+	}
 }

--- a/configuration/mutantenabled.go
+++ b/configuration/mutantenabled.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package configuration
+
+import "github.com/go-gremlins/gremlins/pkg/mutant"
+
+var mutationEnabled = map[mutant.Type]bool{
+	mutant.ArithmeticBase:       true,
+	mutant.ConditionalsBoundary: true,
+	mutant.ConditionalsNegation: true,
+	mutant.IncrementDecrement:   true,
+	mutant.InvertNegatives:      true,
+}
+
+// IsDefaultEnabled returns the default enabled/disabled state of the mutation.
+// It gets the state from the table above that must be kept up to date when adding
+// new mutant types.
+func IsDefaultEnabled(mt mutant.Type) bool {
+	return mutationEnabled[mt]
+}

--- a/configuration/mutantenables_test.go
+++ b/configuration/mutantenables_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package configuration_test
+
+import (
+	"testing"
+
+	"github.com/go-gremlins/gremlins/configuration"
+	"github.com/go-gremlins/gremlins/pkg/mutant"
+)
+
+func TestMutantDefaultStatus(t *testing.T) {
+	testCases := []struct {
+		mutantType mutant.Type
+		expected   bool
+	}{
+		{
+			mutantType: mutant.ArithmeticBase,
+			expected:   true,
+		},
+		{
+			mutantType: mutant.ConditionalsBoundary,
+			expected:   true,
+		},
+		{
+			mutantType: mutant.ConditionalsNegation,
+			expected:   true,
+		},
+		{
+			mutantType: mutant.IncrementDecrement,
+			expected:   true,
+		},
+		{
+			mutantType: mutant.InvertNegatives,
+			expected:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.mutantType.String(), func(t *testing.T) {
+			t.Parallel()
+			got := configuration.IsDefaultEnabled(tc.mutantType)
+
+			if got != tc.expected {
+				t.Errorf("expected %s to be %q, got %q", tc.mutantType, enabled(tc.expected), enabled(got))
+			}
+		})
+	}
+}
+
+func enabled(b bool) string {
+	if b {
+		return "enabled"
+	}
+
+	return "disabled"
+}

--- a/pkg/mutant/mutant.go
+++ b/pkg/mutant/mutant.go
@@ -69,12 +69,21 @@ type Type int
 
 // The currently supported Type in Gremlins.
 const (
-	ConditionalsBoundary Type = iota
+	ArithmeticBase Type = iota
+	ConditionalsBoundary
 	ConditionalsNegation
 	IncrementDecrement
 	InvertNegatives
-	ArithmeticBase
 )
+
+// MutantTypes allows to iterate over Type.
+var MutantTypes = []Type{
+	ArithmeticBase,
+	ConditionalsBoundary,
+	ConditionalsNegation,
+	IncrementDecrement,
+	InvertNegatives,
+}
 
 func (mt Type) String() string {
 	switch mt {

--- a/pkg/mutator/mutator.go
+++ b/pkg/mutator/mutator.go
@@ -174,6 +174,9 @@ func (mu *Mutator) findMutations(set *token.FileSet, file *ast.File, node *inter
 		return
 	}
 	for _, mt := range mutantTypes {
+		if !viper.GetBool(configuration.MutantTypeEnabledKey(mt)) {
+			return
+		}
 		mutantType := mt
 		tm := internal.NewTokenMutant(set, file, node)
 		tm.SetType(mutantType)

--- a/pkg/mutator/testdata/fixtures/0_all_go
+++ b/pkg/mutator/testdata/fixtures/0_all_go
@@ -1,0 +1,27 @@
+package fixtures
+
+import "fmt"
+
+func main() {
+	n := 1 + 1
+	n = 1 - 1
+	n = 1 * 1
+	n = 1 / 1
+	n = 1 % 1
+
+	n++
+	n--
+
+	if n > 0 || n > 100 || n >= 200 || n <= 300 {
+		fmt.Println(n)
+	}
+
+	if n == 0 {
+		fmt.Println(n)
+	}
+	if n != 100 {
+		fmt.Println(n)
+	}
+
+	n = -n
+}


### PR DESCRIPTION
In this PR I have:

- implemented a dynamic flag/configKey generation for all supported mutant types
- added a table of default enablement for all supported `mutant.Type`
- currently the flag format is: `m-<mutant-type> bool` and the config key is `mutants.<mutant-type>.enabled`
  - `--arithmetic-base`
  - `--conditionals-boundary`
  - `--conditionals-negation`
  - `--increment-decrement`
  - `--invert-negatives`

The configuration file now supports:

```yaml
mutants:
  aritmetic-base:
    enabled: true
  conditionals-boundary:
    enabled: true
  conditionals-negation:
    enabled: true
  increment-decrement:
    enabled: true
  invert-negatives:
    enabled: true
```