### PR TITLE
log: add silent mode

### DIFF
--- a/cmd/gremlins.go
+++ b/cmd/gremlins.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/go-gremlins/gremlins/cmd/internal/flags"
 	"github.com/go-gremlins/gremlins/configuration"
 	"github.com/go-gremlins/gremlins/pkg/log"
 )
@@ -79,6 +80,11 @@ and friends.
 
 	}
 	cmd.AddCommand(uc.cmd)
+
+	flag := flags.Flag{Name: "silent", CfgKey: configuration.GremlinsSilentKey, Shorthand: "s", DefaultV: false, Usage: "suppress output and run in silent mode"}
+	if err := flags.SetPersistent(cmd, flag); err != nil {
+		return nil, err
+	}
 
 	return &gremlinsCmd{
 		cmd: cmd,

--- a/cmd/gremlins.go
+++ b/cmd/gremlins.go
@@ -81,7 +81,7 @@ and friends.
 	}
 	cmd.AddCommand(uc.cmd)
 
-	flag := flags.Flag{Name: "silent", CfgKey: configuration.GremlinsSilentKey, Shorthand: "s", DefaultV: false, Usage: "suppress output and run in silent mode"}
+	flag := &flags.Flag{Name: "silent", CfgKey: configuration.GremlinsSilentKey, Shorthand: "s", DefaultV: false, Usage: "suppress output and run in silent mode"}
 	if err := flags.SetPersistent(cmd, flag); err != nil {
 		return nil, err
 	}

--- a/cmd/gremlins_test.go
+++ b/cmd/gremlins_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestGremlins(t *testing.T) {
+	const boolType = "bool"
+
 	c, err := newRootCmd("1.2.3")
 	if err != nil {
 		t.Fatal("newRootCmd should not fail")
@@ -41,6 +43,17 @@ func TestGremlins(t *testing.T) {
 	}
 	if cfgFile.DefValue != "" {
 		t.Errorf("expected default value to be empty, got %v", cfgFile.DefValue)
+	}
+
+	silentFlag := cmd.Flag("silent")
+	if silentFlag == nil {
+		t.Fatal("expected to have a config flag")
+	}
+	if silentFlag.Value.Type() != boolType {
+		t.Errorf("expected value type to be 'bool', got %v", silentFlag.Value.Type())
+	}
+	if silentFlag.DefValue != "false" {
+		t.Errorf("expected default value to be false, got %v", silentFlag.DefValue)
 	}
 }
 

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -35,17 +35,30 @@ type Flag struct {
 // Set is a "generic" function used to set flags on cobra.Command and bind
 // them to viper.Viper.
 func Set(cmd *cobra.Command, flag *Flag) error {
-	flags := cmd.Flags()
+	flagSet := cmd.Flags()
+
+	return setFlags(flag, flagSet)
+}
+
+// SetPersistent is a "generic" function used to set persistent flags
+// on cobra.Command and bind them to viper.Viper.
+func SetPersistent(cmd *cobra.Command, flag *Flag) error {
+	flagSet := cmd.PersistentFlags()
+
+	return setFlags(flag, flagSet)
+}
+
+func setFlags(flag *Flag, fs *pflag.FlagSet) error {
 	switch dv := flag.DefaultV.(type) {
 	// TODO: add a case for all the supported types
 	case bool:
-		setBool(flag, flags, dv)
+		setBool(flag, fs, dv)
 	case string:
-		setString(flag, flags, dv)
+		setString(flag, fs, dv)
 	case float64:
-		setFloat64(flag, flags, dv)
+		setFloat64(flag, fs, dv)
 	}
-	err := viper.BindPFlag(flag.CfgKey, flags.Lookup(flag.Name))
+	err := viper.BindPFlag(flag.CfgKey, fs.Lookup(flag.Name))
 	if err != nil {
 		return err
 	}

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -115,7 +115,7 @@ func TestSet(t *testing.T) {
 			}
 
 			tc.flag.Name += "_persistent"
-			err = SetPersistent(cmd, tc.flag)
+			err = SetPersistent(cmd, &tc.flag)
 			if (tc.expectError && err == nil) || (!tc.expectError && err != nil) {
 				t.Fatal("error not expected")
 			}

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -108,6 +108,23 @@ func TestSet(t *testing.T) {
 			if (tc.expectError && err == nil) || (!tc.expectError && err != nil) {
 				t.Fatal("error not expected")
 			}
+			if !tc.expectError {
+				if cmd.Flags().Lookup(tc.flag.Name) == nil {
+					t.Errorf("expected flag to be present")
+				}
+			}
+
+			tc.flag.Name += "_persistent"
+			err = SetPersistent(cmd, tc.flag)
+			if (tc.expectError && err == nil) || (!tc.expectError && err != nil) {
+				t.Fatal("error not expected")
+			}
+			if !tc.expectError {
+				if cmd.Flag(tc.flag.Name) == nil {
+					t.Errorf("expected flag to be present")
+				}
+			}
+
 		})
 	}
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -31,6 +31,7 @@ import (
 
 // This is the list of the keys available in config files and ad flags.
 const (
+	GremlinsSilentKey            = "silent"
 	UnleashDryRunKey             = "unleash.dry-run"
 	UnleashTagsKey               = "unleash.tags"
 	UnleashThresholdEfficacyKey  = "unleash.threshold.efficacy"

--- a/docs/docs/usage/commands/index.md
+++ b/docs/docs/usage/commands/index.md
@@ -37,3 +37,18 @@ Overrides the configuration file.
 ```shell
 gremlins <command> --config=config.yml
 ```
+
+### Silent
+
+:material-flag:`--silent`/`-s` · :material-sign-direction: Default: false
+
+Makes Gremlins work in _silent mode_, which means only errors will be reported on STDOUT. This is useful in CI runs
+when you don't want to clutter the log, but just read the results from a file or check the exit error code in
+combination with a threshold configuration.
+
+!!! warning
+    Note that Gremlins will be completely silent if there aren't errors, it doesn't mean it is unresponsive.
+
+```shell
+gremlins <command> --silent
+```

--- a/docs/docs/usage/configuration.md
+++ b/docs/docs/usage/configuration.md
@@ -40,6 +40,7 @@ gremlins unleash --config=myConfig.yaml
 Here is a complete configuration file with all the properties set to their defaults:
 
 ```yaml
+silent: false
 unleash:
   dry-run: false
   tags: ""

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
+	"github.com/spf13/viper"
 )
 
 var fgRed = color.New(color.FgRed).SprintFunc()
@@ -93,10 +94,16 @@ type log struct {
 }
 
 func (l *log) writef(f string, args ...any) {
+	if viper.GetBool("silent") {
+		return
+	}
 	_, _ = fmt.Fprintf(l.out, f, args...)
 }
 
 func (l *log) writeln(a any) {
+	if viper.GetBool("silent") {
+		return
+	}
 	_, _ = fmt.Fprintln(l.out, a)
 }
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/spf13/viper"
+
 	"github.com/go-gremlins/gremlins/pkg/log"
 )
 
@@ -113,4 +115,29 @@ func TestLogError(t *testing.T) {
 			t.Errorf("expected out to be empty, got %s", got)
 		}
 	})
+}
+
+func TestSilentMode(t *testing.T) {
+	viper.Set("silent", true)
+	defer viper.Reset()
+
+	sOut := &bytes.Buffer{}
+	defer sOut.Reset()
+	eOut := &bytes.Buffer{}
+	defer eOut.Reset()
+	log.Init(sOut, eOut)
+	defer log.Reset()
+
+	log.Infof("%s", "test")
+	log.Infoln("test")
+	log.Errorf("%s\n", "test")
+	log.Errorln("test")
+
+	if sOut.String() != "" {
+		t.Errorf("expected empty string")
+	}
+	if eOut.String() != "ERROR: test\nERROR: test\n" {
+		t.Log(eOut.String())
+		t.Errorf("expected errors to be reported")
+	}
 }


### PR DESCRIPTION
In this PR I added a _silent_ mode. It can be enabled via `--silent`/`-s`. In this mode, gremlins will be completely silent and just report errors if they happen.