### PR TITLE
coverage: optimize heavy lifting of parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: go.sum
         # Run golangci-lint without action because it is not ready yet fo go1.19
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
       - name: Run golangci-lint
         run: golangci-lint run --version --verbose --out-format=github-actions
 

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -34,7 +34,7 @@ type Flag struct {
 
 // Set is a "generic" function used to set flags on cobra.Command and bind
 // them to viper.Viper.
-func Set(cmd *cobra.Command, flag Flag) error {
+func Set(cmd *cobra.Command, flag *Flag) error {
 	flags := cmd.Flags()
 	switch dv := flag.DefaultV.(type) {
 	// TODO: add a case for all the supported types
@@ -53,7 +53,7 @@ func Set(cmd *cobra.Command, flag Flag) error {
 	return nil
 }
 
-func setFloat64(flag Flag, flags *pflag.FlagSet, dv float64) {
+func setFloat64(flag *Flag, flags *pflag.FlagSet, dv float64) {
 	if flag.Shorthand != "" {
 		flags.Float64P(flag.Name, flag.Shorthand, dv, flag.Usage)
 	} else {
@@ -61,7 +61,7 @@ func setFloat64(flag Flag, flags *pflag.FlagSet, dv float64) {
 	}
 }
 
-func setString(flag Flag, flags *pflag.FlagSet, dv string) {
+func setString(flag *Flag, flags *pflag.FlagSet, dv string) {
 	if flag.Shorthand != "" {
 		flags.StringP(flag.Name, flag.Shorthand, dv, flag.Usage)
 	} else {
@@ -69,7 +69,7 @@ func setString(flag Flag, flags *pflag.FlagSet, dv string) {
 	}
 }
 
-func setBool(flag Flag, flags *pflag.FlagSet, dv bool) {
+func setBool(flag *Flag, flags *pflag.FlagSet, dv bool) {
 	if flag.Shorthand != "" {
 		flags.BoolP(flag.Name, flag.Shorthand, dv, flag.Usage)
 	} else {

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -104,7 +104,7 @@ func TestSet(t *testing.T) {
 
 			cmd := &cobra.Command{}
 
-			err := Set(cmd, tc.flag)
+			err := Set(cmd, &tc.flag)
 			if (tc.expectError && err == nil) || (!tc.expectError && err != nil) {
 				t.Fatal("error not expected")
 			}

--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -157,7 +157,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 		return pflag.NormalizedName(name)
 	})
 
-	fls := []flags.Flag{
+	fls := []*flags.Flag{
 		{Name: paramDryRun, CfgKey: configuration.UnleashDryRunKey, Shorthand: "d", DefaultV: false, Usage: "find mutations but do not executes tests"},
 		{Name: paramBuildTags, CfgKey: configuration.UnleashTagsKey, Shorthand: "t", DefaultV: "", Usage: "a comma-separated list of build tags"},
 		{Name: paramThresholdEfficacy, CfgKey: configuration.UnleashThresholdEfficacyKey, DefaultV: float64(0), Usage: "threshold for code-efficacy percent"},
@@ -182,7 +182,7 @@ func setMutantTypeFlags(cmd *cobra.Command) error {
 		param = strings.ToLower(param)
 		confKey := configuration.MutantTypeEnabledKey(mt)
 
-		err := flags.Set(cmd, flags.Flag{
+		err := flags.Set(cmd, &flags.Flag{
 			Name:     param,
 			CfgKey:   confKey,
 			DefaultV: configuration.IsDefaultEnabled(mt),

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -35,7 +35,7 @@ var instance *log
 //
 // If one of the logging methods is called, and the logger hasn't been
 // initialized yet, a new logger will be initialized with a noOp out.
-func Init(out io.Writer, eOut io.Writer) {
+func Init(out, eOut io.Writer) {
 	if out == nil || eOut == nil {
 		return
 	}


### PR DESCRIPTION
Parameters over 80 bytes should be passed as pointers rather then by
copy. 
Also, update golangci-lint to work with go1.19.
