### PR TITLE
report: add JSON output to file

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -43,6 +43,7 @@ const (
 
 	paramBuildTags = "tags"
 	paramDryRun    = "dry-run"
+	paramOutput    = "output"
 
 	// Thresholds.
 	paramThresholdEfficacy  = "threshold-efficacy"
@@ -160,6 +161,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 	fls := []*flags.Flag{
 		{Name: paramDryRun, CfgKey: configuration.UnleashDryRunKey, Shorthand: "d", DefaultV: false, Usage: "find mutations but do not executes tests"},
 		{Name: paramBuildTags, CfgKey: configuration.UnleashTagsKey, Shorthand: "t", DefaultV: "", Usage: "a comma-separated list of build tags"},
+		{Name: paramOutput, CfgKey: configuration.UnleashOutputKey, Shorthand: "o", DefaultV: "", Usage: "set the output file for machine readable results"},
 		{Name: paramThresholdEfficacy, CfgKey: configuration.UnleashThresholdEfficacyKey, DefaultV: float64(0), Usage: "threshold for code-efficacy percent"},
 		{Name: paramThresholdMCoverage, CfgKey: configuration.UnleashThresholdMCoverageKey, DefaultV: float64(0), Usage: "threshold for mutant-coverage percent"},
 	}

--- a/cmd/unleash_test.go
+++ b/cmd/unleash_test.go
@@ -40,40 +40,59 @@ func TestUnleash(t *testing.T) {
 
 	flags := cmd.Flags()
 
-	// Test for dry-run
-	f := flags.Lookup("dry-run")
-	if f.Value.Type() != "bool" {
-		t.Errorf("expected 'dry-run' to be a 'bool', got %q", f.Value.Type())
-	}
-	if f.DefValue != "false" {
-		t.Errorf("expected 'dry-run' have default 'false', got %q", f.DefValue)
+	testCases := []struct {
+		name      string
+		shorthand string
+		flagType  string
+		defValue  string
+	}{
+		{
+			name:      "dry-run",
+			shorthand: "d",
+			flagType:  "bool",
+			defValue:  "false",
+		},
+		{
+			name:      "tags",
+			shorthand: "t",
+			flagType:  "string",
+			defValue:  "",
+		},
+		{
+			name:     "threshold-efficacy",
+			flagType: "float64",
+			defValue: "0",
+		},
+		{
+			name:     "threshold-mcover",
+			flagType: "float64",
+			defValue: "0",
+		},
+		{
+			name:      "output",
+			shorthand: "o",
+			flagType:  "string",
+			defValue:  "",
+		},
 	}
 
-	// Test for tags
-	f = flags.Lookup("tags")
-	if f.Value.Type() != "string" {
-		t.Errorf("expected 'tags' to be a 'string', got %q", f.Value.Type())
-	}
-	if f.DefValue != "" {
-		t.Errorf("expected 'tags' not to be set by default, got %q", f.DefValue)
-	}
-
-	// test threshold-efficacy
-	f = flags.Lookup("threshold-efficacy")
-	if f.Value.Type() != "float64" {
-		t.Errorf("expected 'threshold-efficacy' to be a 'float64', got %q", f.Value.Type())
-	}
-	if f.DefValue != "0" {
-		t.Errorf("expected 'threshold-efficacy' have default '0', got %q", f.DefValue)
-	}
-
-	// test threshold-mcover
-	f = flags.Lookup("threshold-mcover")
-	if f.Value.Type() != "float64" {
-		t.Errorf("expected 'threshold-mcover' to be a 'float64', got %q", f.Value.Type())
-	}
-	if f.DefValue != "0" {
-		t.Errorf("expected 'threshold-mcover' have default '0', got %q", f.DefValue)
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := flags.Lookup(tc.name)
+			if f == nil {
+				t.Fatalf("expected flag %q to be registered", tc.name)
+			}
+			if tc.shorthand != "" && f.Shorthand != tc.shorthand {
+				t.Errorf("expected %q to have a shorthand %q, got %q", tc.name, tc.shorthand, f.Shorthand)
+			}
+			if f.Value.Type() != tc.flagType {
+				t.Errorf("expected %q to be type %q, got %q", tc.name, f.Value.Type(), f.Value.Type())
+			}
+			if f.DefValue != tc.defValue {
+				t.Errorf("expected %q to have default value %q, got %q", tc.name, tc.defValue, f.DefValue)
+			}
+		})
 	}
 
 	// test for MutantTypes flags

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -32,6 +32,7 @@ import (
 // This is the list of the keys available in config files and ad flags.
 const (
 	UnleashDryRunKey             = "unleash.dry-run"
+	UnleashOutputKey             = "unleash.output"
 	UnleashTagsKey               = "unleash.tags"
 	UnleashThresholdEfficacyKey  = "unleash.threshold.efficacy"
 	UnleashThresholdMCoverageKey = "unleash.threshold.mutant-coverage"
@@ -85,7 +86,7 @@ func Init(cPaths []string) error {
 // The generated key will have the format 'mutants.mutant-name.enabled",
 // which corresponds to the Yaml:
 //
-//			mutants:
+//		mutants:
 //	 		mutant-name:
 //	 			enabled: [bool]
 func MutantTypeEnabledKey(mt mutant.Type) string {

--- a/docs/docs/schema/configuration.json
+++ b/docs/docs/schema/configuration.json
@@ -28,6 +28,15 @@
             "tag1,tag2,tag4"
           ]
         },
+        "output": {
+          "title": "Output",
+          "description": "The output file for machine readable results",
+          "type": "string",
+          "default": "",
+          "examples": [
+            "output.json"
+          ]
+        },
         "threshold": {
           "title": "Thresholds",
           "description": "The thresholds under which Gremlins exits with an error",

--- a/docs/docs/usage/commands/unleash.md
+++ b/docs/docs/usage/commands/unleash.md
@@ -41,6 +41,53 @@ Sets the `go` command build tags.
 gremlins unleash --tags "tag1,tag2"
 ```
 
+### Output
+
+:material-flag: `--output`/`-o` · :material-sign-direction: Default: empty
+
+When set, Gremlins will write the give output file with machine readable results.
+
+```shell
+gremlins unleash --output=output.json
+```
+
+The output file in in JSON format and has the following structure:
+
+```json
+{
+  "go_module": "github.com/go-gremlins/gremlins",
+  "test_efficacy": 82.00, //(1)
+  "mutations_coverage": 80.00, //(2)
+  "mutants_total": 100,
+  "mutants_killed": 82,
+  "mutants_lived": 8,
+  "mutants_not_viable": 2, //(3)
+  "mutants_not_covered": 10,
+  "elapsed_time": 123.456, //(4)
+  "files": [
+    {
+      "file_name": "myFile.go",
+      "mutations": [
+        {
+          "line": 10,
+          "column": 8,
+          "type": "CONDITIONALS_NEGATION",
+          "status": "KILLED"
+        }
+      ]
+    }
+  ]
+}
+```
+
+1. This is a percentage expressed as floating point number.
+2. This is a percentage expressed as floating point number.
+3. NOT VIABLE mutants are excluded from all the calculations.
+4. The elapsed time is expressed in seconds, expressed as floating point number.
+
+!!! warning
+    The JSON output file is not _pretty printed_; it is optimised for machine reading.
+
 ### Threshold efficacy
 :material-flag: `--threshold-efficacy` · :material-sign-direction: Default: 0
 

--- a/docs/docs/usage/configuration.md
+++ b/docs/docs/usage/configuration.md
@@ -43,6 +43,7 @@ Here is a complete configuration file with all the properties set to their defau
 unleash:
   dry-run: false
   tags: ""
+  output: ""
   threshold: #(1)
     efficacy: 0
     mutant-coverage: 0
@@ -64,8 +65,9 @@ mutants:
 1. Thresholds are set by default to `0`, which means they are not enforced. For further information check the specific
    documentation.
 
-You can validate the configuration file using the provided JSON Schema (ex. using it in your editor). The schema
-can be found at [{{ config.site_url }}/schema/configuration.json]({{ config.site_url }}/schema/configuration.json). 
+!!! tip
+    You can validate the configuration file using the provided JSON Schema (ex. using it in your editor). The schema
+    can be found at [{{ config.site_url }}/schema/configuration.json]({{ config.site_url }}/schema/configuration.json). 
 
 ## Environment variables
 

--- a/pkg/coverage/coverage.go
+++ b/pkg/coverage/coverage.go
@@ -37,6 +37,7 @@ import (
 // it took to generate the coverage report.
 type Result struct {
 	Profile Profile
+	Module  string
 	Elapsed time.Duration
 }
 
@@ -120,7 +121,7 @@ func (c *Coverage) Run() (Result, error) {
 		return Result{}, fmt.Errorf("an error occurred while generating coverage profile: %w", err)
 	}
 
-	return Result{profile, elapsed}, nil
+	return Result{Module: c.mod, Profile: profile, Elapsed: elapsed}, nil
 }
 
 func (c *Coverage) getProfile() (Profile, error) {

--- a/pkg/coverage/coverage_test.go
+++ b/pkg/coverage/coverage_test.go
@@ -69,7 +69,8 @@ func TestCoverageRunFails(t *testing.T) {
 
 func TestCoverageParsesOutput(t *testing.T) {
 	t.Parallel()
-	cov := coverage.NewWithCmdAndPackage(fakeExecCommandSuccess(nil), "example.com", "testdata/valid", "./...")
+	module := "example.com"
+	cov := coverage.NewWithCmdAndPackage(fakeExecCommandSuccess(nil), module, "testdata/valid", "./...")
 	profile := coverage.Profile{
 		"path/file1.go": {
 			{
@@ -89,6 +90,7 @@ func TestCoverageParsesOutput(t *testing.T) {
 		},
 	}
 	want := coverage.Result{
+		Module:  module,
 		Profile: profile,
 	}
 
@@ -98,6 +100,9 @@ func TestCoverageParsesOutput(t *testing.T) {
 	}
 
 	if !cmp.Equal(got.Profile, want.Profile) {
+		t.Error(cmp.Diff(got, want))
+	}
+	if !cmp.Equal(got.Module, want.Module) {
 		t.Error(cmp.Diff(got, want))
 	}
 	if got.Elapsed == 0 {

--- a/pkg/mutator/mutator.go
+++ b/pkg/mutator/mutator.go
@@ -53,6 +53,7 @@ type Mutator struct {
 	rollback          func(m mutant.Mutant) error
 	mutantStream      chan mutant.Mutant
 	buildTags         string
+	module            string
 	testExecutionTime time.Duration
 	dryRun            bool
 }
@@ -80,6 +81,7 @@ func New(fs fs.FS, r coverage.Result, manager workdir.Dealer, opts ...Option) Mu
 	dryRun := viper.GetBool(configuration.UnleashDryRunKey)
 
 	mut := Mutator{
+		module:            r.Module,
 		wdManager:         manager,
 		covProfile:        r.Profile,
 		testExecutionTime: r.Elapsed * timeoutCoefficient,
@@ -146,6 +148,7 @@ func (mu *Mutator) Run() report.Results {
 	start := time.Now()
 	res := mu.executeTests()
 	res.Elapsed = time.Since(start)
+	res.Module = mu.module
 
 	return res
 }

--- a/pkg/mutator/mutator_test.go
+++ b/pkg/mutator/mutator_test.go
@@ -394,7 +394,7 @@ func TestMutatorRun(t *testing.T) {
 	}
 
 	timeoutDifference := absTimeDiff(holder.timeout, expectedTimeout*2)
-	diffThreshold := 50 * time.Microsecond
+	diffThreshold := 70 * time.Microsecond
 	if timeoutDifference > diffThreshold {
 		t.Errorf("expected timeout to be within %s from the set timeout, got %s", diffThreshold, timeoutDifference)
 	}

--- a/pkg/mutator/mutator_test.go
+++ b/pkg/mutator/mutator_test.go
@@ -62,19 +62,20 @@ func viperReset() {
 }
 
 const expectedTimeout = 10 * time.Second
+const expectedModule = "example.com"
 
 func coveredPosition(fixture string) coverage.Result {
 	fn := filenameFromFixture(fixture)
 	p := coverage.Profile{fn: {{StartLine: 6, EndLine: 7, StartCol: 8, EndCol: 9}}}
 
-	return coverage.Result{Profile: p, Elapsed: expectedTimeout}
+	return coverage.Result{Module: expectedModule, Profile: p, Elapsed: expectedTimeout}
 }
 
 func notCoveredPosition(fixture string) coverage.Result {
 	fn := filenameFromFixture(fixture)
 	p := coverage.Profile{fn: {{StartLine: 9, EndLine: 9, StartCol: 8, EndCol: 9}}}
 
-	return coverage.Result{Profile: p, Elapsed: expectedTimeout}
+	return coverage.Result{Module: expectedModule, Profile: p, Elapsed: expectedTimeout}
 }
 
 type dealerStub struct{}
@@ -273,6 +274,10 @@ func TestMutations(t *testing.T) {
 			mut := mutator.New(mapFS, tCase.covResult, dealerStub{})
 			res := mut.Run()
 			got := res.Mutants
+
+			if res.Module != expectedModule {
+				t.Errorf("expected module to be %q, got %q", expectedModule, res.Module)
+			}
 
 			if tCase.token == token.ILLEGAL {
 				if len(got) != 0 {

--- a/pkg/report/internal/structure.go
+++ b/pkg/report/internal/structure.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package internal
+
+// OutputResult is the data structure for the Gremlins file output format.
+type OutputResult struct {
+	GoModule          string       `json:"go_module"`
+	Files             []OutputFile `json:"files"`
+	TestEfficacy      float64      `json:"test_efficacy"`
+	MutationsCoverage float64      `json:"mutations_coverage"`
+	MutantsTotal      int          `json:"mutants_total"`
+	MutantsKilled     int          `json:"mutants_killed"`
+	MutantsLived      int          `json:"mutants_lived"`
+	MutantsNotViable  int          `json:"mutants_not_viable"`
+	MutantsNotCovered int          `json:"mutants_not_covered"`
+	ElapsedTime       float64      `json:"elapsed_time"`
+}
+
+// OutputFile represents a single file in the OutputResult data structure.
+type OutputFile struct {
+	Filename  string     `json:"file_name"`
+	Mutations []Mutation `json:"mutations"`
+}
+
+// Mutation represents a single mutation in the OutputResult data structure.
+type Mutation struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+}

--- a/pkg/report/testdata/normal_output.json
+++ b/pkg/report/testdata/normal_output.json
@@ -1,0 +1,58 @@
+{
+  "go_module": "example.com/go/module",
+  "test_efficacy": 50,
+  "mutations_coverage": 50,
+  "mutants_total": 3,
+  "mutants_killed": 1,
+  "mutants_lived": 1,
+  "mutants_not_viable": 1,
+  "mutants_not_covered": 2,
+  "elapsed_time": 142.123,
+  "files": [
+    {
+      "file_name": "file1.go",
+      "mutations": [
+        {
+          "line": 10,
+          "column": 3,
+          "type": "CONDITIONALS_NEGATION",
+          "status": "KILLED"
+        },
+        {
+          "line": 20,
+          "column": 8,
+          "type": "ARITHMETIC_BASE",
+          "status": "LIVED"
+        }
+      ]
+    },
+    {
+      "file_name": "file2.go",
+      "mutations": [
+        {
+          "line": 20,
+          "column": 3,
+          "type": "INCREMENT_DECREMENT",
+          "status": "NOT COVERED"
+        },
+        {
+          "line": 500,
+          "column": 3,
+          "type": "CONDITIONALS_BOUNDARY",
+          "status": "NOT COVERED"
+        }
+      ]
+    },
+    {
+      "file_name": "file3.go",
+      "mutations": [
+        {
+          "line": 200,
+          "column": 4,
+          "type": "INVERT_NEGATIVES",
+          "status": "NOT VIABLE"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In this PR I

- added a `--output`/`-o` flag to `unleash`
- if set, it will print a JSON file with all the results
- updated the documentation accordingly

If the output file is not writeable, gremlins will log the fact, but will not exit with an error.