### PR TITLE
report: fix get as float if stored as int

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -186,10 +186,16 @@ func (r *reportStatus) assess(tEfficacy, rCoverage float64) error {
 	}
 
 	et := configuration.Get[float64](configuration.UnleashThresholdEfficacyKey)
+	if et == 0 {
+		et = float64(configuration.Get[int](configuration.UnleashThresholdEfficacyKey))
+	}
 	if et > 0 && tEfficacy <= et {
 		return execution.NewExitErr(execution.EfficacyThreshold)
 	}
 	ct := configuration.Get[float64](configuration.UnleashThresholdMCoverageKey)
+	if ct == 0 {
+		ct = float64(configuration.Get[int](configuration.UnleashThresholdMCoverageKey))
+	}
 	if ct > 0 && rCoverage <= ct {
 		return execution.NewExitErr(execution.MutantCoverageThreshold)
 	}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -149,7 +149,7 @@ func TestAssessment(t *testing.T) {
 		confKey     string
 		expectError bool
 	}{
-		// Efficacy-threshold
+		// Efficacy-threshold as float64
 		{
 			name:        "efficacy < efficacy-threshold",
 			confKey:     configuration.UnleashThresholdEfficacyKey,
@@ -165,10 +165,17 @@ func TestAssessment(t *testing.T) {
 		{
 			name:        "efficacy-threshold == 0",
 			confKey:     configuration.UnleashThresholdEfficacyKey,
-			value:       0,
+			value:       float64(0),
 			expectError: false,
 		},
-		// Mutant coverage-threshold
+		// Efficacy-threshold as float64
+		{
+			name:        "efficacy < efficacy-threshold",
+			confKey:     configuration.UnleashThresholdEfficacyKey,
+			value:       51,
+			expectError: true,
+		},
+		// Mutant coverage-threshold as float
 		{
 			name:        "coverage < coverage-threshold",
 			confKey:     configuration.UnleashThresholdMCoverageKey,
@@ -184,8 +191,15 @@ func TestAssessment(t *testing.T) {
 		{
 			name:        "coverage-threshold == 0",
 			confKey:     configuration.UnleashThresholdMCoverageKey,
-			value:       0,
+			value:       float64(0),
 			expectError: false,
+		},
+		// Mutant coverage-threshold as int
+		{
+			name:        "coverage < coverage-threshold",
+			confKey:     configuration.UnleashThresholdMCoverageKey,
+			value:       51,
+			expectError: true,
 		},
 	}
 


### PR DESCRIPTION
After the generification of Viper get, if a numerical value was
stored without making it an explicit float, when retrieved
as float64 it was always 0.

