### PR TITLE
docs: fix source install instruction

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -87,7 +87,7 @@ sudo cp gremlins_{{ release.full_version }}_linux_amd64/gremlins /usr/bin
 Gremlins can be installed with the Go install command. Only the [Go compiler](https://go.dev) is needed.
 
 ```sh
-go install https://github.com/go-gremlins/gremlins/cmd/gremlins@v{{ release.full_version }}
+go install github.com/go-gremlins/gremlins/cmd/gremlins@v{{ release.full_version }}
 ```
 
 ### :material-ninja: Ninja style


### PR DESCRIPTION
`go install` argument cannot contain protocol

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/CONTRIBUTING.md) doc
