### PR TITLE
mutator: fix resource leakage

### DIFF
--- a/pkg/mutator/mutator.go
+++ b/pkg/mutator/mutator.go
@@ -310,6 +310,7 @@ func (mu *Mutator) getTestArgs() []string {
 	if mu.buildTags != "" {
 		args = append(args, "-tags", mu.buildTags)
 	}
+	args = append(args, "-timeout", (1*time.Second + mu.testExecutionTime).String())
 	args = append(args, "./...")
 
 	return args

--- a/pkg/mutator/mutator_test.go
+++ b/pkg/mutator/mutator_test.go
@@ -385,7 +385,7 @@ func TestMutatorRun(t *testing.T) {
 
 	_ = mut.Run(context.Background())
 
-	want := "go test -tags tag1 tag2 ./..."
+	want := "go test -tags tag1 tag2 -timeout 21s ./..."
 	got := fmt.Sprintf("go %v", strings.Join(holder.args, " "))
 
 	if !cmp.Equal(got, want) {


### PR DESCRIPTION
There was a resource leakage since we the external management of timeout. Gremlins killed the test process, but not the child processes that remained hanging forever.