### PR TITLE
coverage: print combined output in case of failure

### DIFF
--- a/pkg/coverage/coverage.go
+++ b/pkg/coverage/coverage.go
@@ -144,10 +144,10 @@ func (c *Coverage) executeCoverage() (time.Duration, error) {
 
 	args = append(args, "-cover", "-coverprofile", c.filePath(), c.scanPath())
 	cmd := c.cmdContext("go", args...)
-	cmd.Stderr = os.Stderr
 
 	start := time.Now()
-	if err := cmd.Run(); err != nil {
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Infof("\n%s\n", string(out))
 		return 0, err
 	}
 

--- a/pkg/coverage/coverage.go
+++ b/pkg/coverage/coverage.go
@@ -148,6 +148,7 @@ func (c *Coverage) executeCoverage() (time.Duration, error) {
 	start := time.Now()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		log.Infof("\n%s\n", string(out))
+
 		return 0, err
 	}
 

--- a/pkg/mutator/mutator.go
+++ b/pkg/mutator/mutator.go
@@ -181,12 +181,6 @@ func (mu *Mutator) mutationStatus(pos token.Position) mutant.Status {
 }
 
 func (mu *Mutator) executeTests(ctx context.Context) report.Results {
-	// TODO: add config for CPU
-	// - if integration mode, use half cpu
-	// - if cpu not set, use numCPU
-	// - make timeout coefficient configurable
-	// - make test cpu configurable
-	// - set sensible defaults
 	pool := workerpool.Initialize("mutator")
 	pool.Start()
 


### PR DESCRIPTION
Now, if the coverage run fails, it will print the combined output of the command instead of a cryptic "exit code 1".