### PR TITLE
mutant: refactor to respect Go convention

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -205,7 +205,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 }
 
 func setMutantTypeFlags(cmd *cobra.Command) error {
-	for _, mt := range mutant.MutantTypes {
+	for _, mt := range mutant.Types {
 		name := mt.String()
 		usage := fmt.Sprintf("enable %q mutants", name)
 		param := strings.ReplaceAll(name, "_", "-")

--- a/cmd/unleash_test.go
+++ b/cmd/unleash_test.go
@@ -116,7 +116,7 @@ func TestUnleash(t *testing.T) {
 	}
 
 	// test for MutantTypes flags
-	for _, mt := range mutant.MutantTypes {
+	for _, mt := range mutant.Types {
 		s := strings.ToLower(mt.String())
 		mtf := flags.Lookup(s)
 		if mtf == nil {

--- a/pkg/mutant/mutant.go
+++ b/pkg/mutant/mutant.go
@@ -77,8 +77,8 @@ const (
 	InvertNegatives
 )
 
-// MutantTypes allows to iterate over Type.
-var MutantTypes = []Type{
+// Types allows to iterate over Type.
+var Types = []Type{
 	ArithmeticBase,
 	ConditionalsBoundary,
 	ConditionalsNegation,

--- a/pkg/mutator/mutator_test.go
+++ b/pkg/mutator/mutator_test.go
@@ -284,7 +284,7 @@ func TestMutations(t *testing.T) {
 
 func TestMutantSkipDisabled(t *testing.T) {
 	t.Parallel()
-	for _, mt := range mutant.MutantTypes {
+	for _, mt := range mutant.Types {
 		mt := mt
 		t.Run(mt.String(), func(t *testing.T) {
 			t.Parallel()

--- a/pkg/mutator/stubs_test.go
+++ b/pkg/mutator/stubs_test.go
@@ -48,7 +48,7 @@ func viperSet(set map[string]any) {
 
 func viperReset() {
 	configuration.Reset()
-	for _, mt := range mutant.MutantTypes {
+	for _, mt := range mutant.Types {
 		configuration.Set(configuration.MutantTypeEnabledKey(mt), true)
 	}
 	viperMutex.Unlock()


### PR DESCRIPTION
Exported names should not start with the package name, in this case
mutant.MutantTypes should be mutant.Types, and that's exactly
what I did here.
