### PR TITLE
mutant: add INVERT_LOOPCTRL mutation

### DIFF
--- a/docs/docs/schema/configuration.json
+++ b/docs/docs/schema/configuration.json
@@ -145,6 +145,20 @@
               "default": true
             }
           }
+        },
+        "invert-loopctrl": {
+          "title": "The invert-loopctrl Schema",
+          "type": "object",
+          "required": [
+            "enabled"
+          ],
+          "properties": {
+            "enabled": {
+              "title": "The enabled Schema",
+              "type": "boolean",
+              "default": true
+            }
+          }
         }
       }
     }

--- a/docs/docs/schema/configuration.json
+++ b/docs/docs/schema/configuration.json
@@ -156,7 +156,7 @@
             "enabled": {
               "title": "The enabled Schema",
               "type": "boolean",
-              "default": true
+              "default": false
             }
           }
         }

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -199,6 +199,16 @@ Enables/disables the [INVERT LOGICAL](../../mutations/invert_logical.md) mutant 
 gremlins unleash --invert_logical=true
 ```
 
+### Invert loop control
+
+:material-flag: `--invert-loopctrl` · :material-sign-direction: Default: `true`
+
+Enables/disables the [INVERT LOOP](../../mutations/invert_loop.md) mutant type.
+
+```shell
+gremlins unleash --invert-loopctrl
+```
+
 ### Workers
 
 :material-flag: `--workers` · :material-sign-direction: Default: `0`

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -201,7 +201,7 @@ gremlins unleash --invert_logical=true
 
 ### Invert loop control
 
-:material-flag: `--invert-loopctrl` · :material-sign-direction: Default: `true`
+:material-flag: `--invert-loopctrl` · :material-sign-direction: Default: `false`
 
 Enables/disables the [INVERT LOOP](../../mutations/invert_loop.md) mutant type.
 

--- a/docs/docs/usage/configuration.md
+++ b/docs/docs/usage/configuration.md
@@ -71,7 +71,7 @@ mutants:
   invert-logical:
     enabled: false
   invert-loopctrl:
-    enabled: true
+    enabled: false
 
 ```
 

--- a/docs/docs/usage/configuration.md
+++ b/docs/docs/usage/configuration.md
@@ -70,6 +70,8 @@ mutants:
     enabled: true
   invert-logical:
     enabled: false
+  invert-loopctrl:
+    enabled: true
 
 ```
 

--- a/docs/docs/usage/mutations/index.md
+++ b/docs/docs/usage/mutations/index.md
@@ -12,11 +12,12 @@ A _mutant_ is the "gremlin" that actually changes the source code.
 
 Each _mutant type_ can be enabled or disabled, and only a subset of mutations is enabled by default.
 
-| MutationType                                      |  Default  |
-|---------------------------------------------------|:---------:|
-| [ARITHMETIC BASE](arithmetic_base.md)             |    YES    |
-| [CONDITIONALS BOUNDARY](conditionals_boundary.md) |    YES    |
-| [CONDITIONALS NEGATION](conditionals_negation.md) |    YES    |
-| [INCREMENT DECREMENT](increment_decrement.md)     |    YES    |
-| [INVERT NEGATIVES ](invert_negatives.md)          |    YES    |
-| [INVERT LOGICAL ](invert_logical.md)              |   FALSE   |
+| MutationType                                      | Default  |
+|---------------------------------------------------|:--------:|
+| [ARITHMETIC BASE](arithmetic_base.md)             |   YES    |
+| [CONDITIONALS BOUNDARY](conditionals_boundary.md) |   YES    |
+| [CONDITIONALS NEGATION](conditionals_negation.md) |   YES    |
+| [INCREMENT DECREMENT](increment_decrement.md)     |   YES    |
+| [INVERT NEGATIVES ](invert_negatives.md)          |   YES    |
+| [INVERT LOOP CTRL ](invert_loop.md)               |   YES    |
+| [INVERT LOGICAL ](invert_logical.md)              |  FALSE   |

--- a/docs/docs/usage/mutations/index.md
+++ b/docs/docs/usage/mutations/index.md
@@ -12,12 +12,12 @@ A _mutant_ is the "gremlin" that actually changes the source code.
 
 Each _mutant type_ can be enabled or disabled, and only a subset of mutations is enabled by default.
 
-| MutationType                                      | Default  |
-|---------------------------------------------------|:--------:|
-| [ARITHMETIC BASE](arithmetic_base.md)             |   YES    |
-| [CONDITIONALS BOUNDARY](conditionals_boundary.md) |   YES    |
-| [CONDITIONALS NEGATION](conditionals_negation.md) |   YES    |
-| [INCREMENT DECREMENT](increment_decrement.md)     |   YES    |
-| [INVERT NEGATIVES ](invert_negatives.md)          |   YES    |
-| [INVERT LOOP CTRL ](invert_loop.md)               |   YES    |
-| [INVERT LOGICAL ](invert_logical.md)              |  FALSE   |
+| MutationType                                      |  Default   |
+|---------------------------------------------------|:----------:|
+| [ARITHMETIC BASE](arithmetic_base.md)             |    YES     |
+| [CONDITIONALS BOUNDARY](conditionals_boundary.md) |    YES     |
+| [CONDITIONALS NEGATION](conditionals_negation.md) |    YES     |
+| [INCREMENT DECREMENT](increment_decrement.md)     |    YES     |
+| [INVERT NEGATIVES ](invert_negatives.md)          |    YES     |
+| [INVERT LOGICAL ](invert_logical.md)              |   FALSE    |
+| [INVERT LOOP CTRL ](invert_loop.md)               |   FALSE    |

--- a/docs/docs/usage/mutations/invert_loop.md
+++ b/docs/docs/usage/mutations/invert_loop.md
@@ -4,7 +4,7 @@ title: Invert loop
 
 # Invert loop control
 
-_Invert loop control_ will perform inversions on control operations, which means a `continue` will become a `break`..
+_Invert loop control_ will perform inversions on control operations, which means a `continue` will become a `break`.
 
 ## Mutation table
 

--- a/docs/docs/usage/mutations/invert_loop.md
+++ b/docs/docs/usage/mutations/invert_loop.md
@@ -1,0 +1,36 @@
+---
+title: Invert loop
+---
+
+# Invert loop control
+
+_Invert loop control_ will perform inversions on control operations, which means a `continue` will become a `break`..
+
+## Mutation table
+
+[//]: # (@formatter:off)
+
+|   Orig   | Mutation |
+|:--------:|:--------:|
+| continue |  break   |
+|  break   | continue |
+
+[//]: # (@formatter:on)
+
+## Examples
+
+=== "Original"
+
+    ```go
+    for i := 0; i < 3; i++ {
+        continue
+    }
+    ```
+
+=== "Mutated"
+
+    ```go
+    for i := 0; i < 3; i++ {
+        break
+    }
+    ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
           - usage/mutations/increment_decrement.md
           - usage/mutations/invert_negatives.md
           - usage/mutations/invert_logical.md
+          - usage/mutations/invert_loop.md
       - Continuous integration:
           - usage/ci/github-action.md
           - usage/ci/docker.md

--- a/internal/configuration/mutantenabled.go
+++ b/internal/configuration/mutantenabled.go
@@ -27,7 +27,7 @@ var mutationEnabled = map[mutator.Type]bool{
 	mutator.IncrementDecrement:   true,
 	mutator.InvertLogical:        false,
 	mutator.InvertNegatives:      true,
-	mutator.InvertLoopCtrl:       true,
+	mutator.InvertLoopCtrl:       false,
 }
 
 // IsDefaultEnabled returns the default enabled/disabled state of the mutation.

--- a/internal/configuration/mutantenabled.go
+++ b/internal/configuration/mutantenabled.go
@@ -27,6 +27,7 @@ var mutationEnabled = map[mutator.Type]bool{
 	mutator.IncrementDecrement:   true,
 	mutator.InvertLogical:        false,
 	mutator.InvertNegatives:      true,
+	mutator.InvertLoopCtrl:       true,
 }
 
 // IsDefaultEnabled returns the default enabled/disabled state of the mutation.

--- a/internal/configuration/mutantenables_test.go
+++ b/internal/configuration/mutantenables_test.go
@@ -54,6 +54,10 @@ func TestMutantDefaultStatus(t *testing.T) {
 			mutantType: mutator.InvertNegatives,
 			expected:   true,
 		},
+		{
+			mutantType: mutator.InvertLoopCtrl,
+			expected:   true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/configuration/mutantenables_test.go
+++ b/internal/configuration/mutantenables_test.go
@@ -56,7 +56,7 @@ func TestMutantDefaultStatus(t *testing.T) {
 		},
 		{
 			mutantType: mutator.InvertLoopCtrl,
-			expected:   true,
+			expected:   false,
 		},
 	}
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -226,6 +226,22 @@ func TestMutations(t *testing.T) {
 			covResult:  notCoveredPosition("testdata/fixtures/lor_go"),
 			mutStatus:  mutator.NotCovered,
 		},
+		{
+			name:       "it recognizes INVERT_LOOPCTRL with CONTINUE",
+			fixture:    "testdata/fixtures/loop_continue_go",
+			mutantType: mutator.InvertLoopCtrl,
+			token:      token.CONTINUE,
+			covResult:  notCoveredPosition("testdata/fixtures/loop_continue_go"),
+			mutStatus:  mutator.NotCovered,
+		},
+		{
+			name:       "it recognizes INVERT_LOOPCTRL with BREAK",
+			fixture:    "testdata/fixtures/loop_break_go",
+			mutantType: mutator.InvertLoopCtrl,
+			token:      token.BREAK,
+			covResult:  notCoveredPosition("testdata/fixtures/loop_break_go"),
+			mutStatus:  mutator.NotCovered,
+		},
 		// Common behaviours
 		{
 			name:       "it works with recursion",

--- a/internal/engine/mappings.go
+++ b/internal/engine/mappings.go
@@ -25,21 +25,23 @@ import (
 // TokenMutantType is the mapping from each token.Token and all the
 // mutator.Type that can be applied to it.
 var TokenMutantType = map[token.Token][]mutator.Type{
-	token.SUB:  {mutator.InvertNegatives, mutator.ArithmeticBase},
-	token.ADD:  {mutator.ArithmeticBase},
-	token.MUL:  {mutator.ArithmeticBase},
-	token.QUO:  {mutator.ArithmeticBase},
-	token.REM:  {mutator.ArithmeticBase},
-	token.EQL:  {mutator.ConditionalsNegation},
-	token.NEQ:  {mutator.ConditionalsNegation},
-	token.GTR:  {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
-	token.LSS:  {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
-	token.GEQ:  {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
-	token.LEQ:  {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
-	token.INC:  {mutator.IncrementDecrement},
-	token.DEC:  {mutator.IncrementDecrement},
-	token.LAND: {mutator.InvertLogical},
-	token.LOR:  {mutator.InvertLogical},
+	token.SUB:      {mutator.InvertNegatives, mutator.ArithmeticBase},
+	token.ADD:      {mutator.ArithmeticBase},
+	token.MUL:      {mutator.ArithmeticBase},
+	token.QUO:      {mutator.ArithmeticBase},
+	token.REM:      {mutator.ArithmeticBase},
+	token.EQL:      {mutator.ConditionalsNegation},
+	token.NEQ:      {mutator.ConditionalsNegation},
+	token.GTR:      {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
+	token.LSS:      {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
+	token.GEQ:      {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
+	token.LEQ:      {mutator.ConditionalsBoundary, mutator.ConditionalsNegation},
+	token.INC:      {mutator.IncrementDecrement},
+	token.DEC:      {mutator.IncrementDecrement},
+	token.LAND:     {mutator.InvertLogical},
+	token.LOR:      {mutator.InvertLogical},
+	token.BREAK:    {mutator.InvertLoopCtrl},
+	token.CONTINUE: {mutator.InvertLoopCtrl},
 }
 
 var tokenMutations = map[mutator.Type]map[token.Token]token.Token{
@@ -74,5 +76,9 @@ var tokenMutations = map[mutator.Type]map[token.Token]token.Token{
 	},
 	mutator.InvertNegatives: {
 		token.SUB: token.ADD,
+	},
+	mutator.InvertLoopCtrl: {
+		token.BREAK:    token.CONTINUE,
+		token.CONTINUE: token.BREAK,
 	},
 }

--- a/internal/engine/node.go
+++ b/internal/engine/node.go
@@ -45,6 +45,9 @@ func NewTokenNode(n ast.Node) (*NodeToken, bool) {
 	case *ast.IncDecStmt:
 		tok = &n.Tok
 		pos = n.TokPos
+	case *ast.BranchStmt:
+		tok = &n.Tok
+		pos = n.TokPos
 	default:
 		return &NodeToken{}, false
 	}

--- a/internal/engine/node_test.go
+++ b/internal/engine/node_test.go
@@ -67,6 +67,16 @@ func TestNewTokenNode(t *testing.T) {
 			supported: true,
 		},
 		{
+			name: "BranchStmt",
+			node: &ast.BranchStmt{
+				TokPos: 123,
+				Tok:    token.CONTINUE,
+			},
+			wantTok:   token.CONTINUE,
+			wantPos:   123,
+			supported: true,
+		},
+		{
 			name: "not supported",
 			node: &ast.BasicLit{
 				ValuePos: 123,

--- a/internal/engine/testdata/fixtures/loop_break_go
+++ b/internal/engine/testdata/fixtures/loop_break_go
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+  for {
+    break
+  } 
+}

--- a/internal/engine/testdata/fixtures/loop_continue_go
+++ b/internal/engine/testdata/fixtures/loop_continue_go
@@ -1,0 +1,7 @@
+package main
+
+func main() {
+  for i := 0; i < 3; i++ {
+     continue
+  } 
+}

--- a/internal/mutator/mutator.go
+++ b/internal/mutator/mutator.go
@@ -75,6 +75,7 @@ const (
 	IncrementDecrement
 	InvertLogical
 	InvertNegatives
+	InvertLoopCtrl
 )
 
 // Types allows to iterate over Type.
@@ -85,6 +86,7 @@ var Types = []Type{
 	IncrementDecrement,
 	InvertLogical,
 	InvertNegatives,
+	InvertLoopCtrl,
 }
 
 func (mt Type) String() string {
@@ -101,6 +103,8 @@ func (mt Type) String() string {
 		return "INVERT_NEGATIVES"
 	case ArithmeticBase:
 		return "ARITHMETIC_BASE"
+	case InvertLoopCtrl:
+		return "INVERT_LOOPCTRL"
 	default:
 		panic("this should not happen")
 	}

--- a/internal/mutator/mutator_test.go
+++ b/internal/mutator/mutator_test.go
@@ -107,6 +107,11 @@ func TestTypeString(t *testing.T) {
 			expected:   "ARITHMETIC_BASE",
 			mutantType: mutator.ArithmeticBase,
 		},
+		{
+			name:       "INVERT_LOOPCTRL",
+			expected:   "INVERT_LOOPCTRL",
+			mutantType: mutator.InvertLoopCtrl,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
## Proposed changes

Implement #136 invert loop break/continue

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I've added the loop control support. I'm not sure if the fixtures are good enough.
I was wondering what will happen when changing the control results in an infinite loop?