### PR TITLE
coverage: add support for flag --coverpkg

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -47,6 +47,7 @@ const (
 	commandName = "unleash"
 
 	paramBuildTags          = "tags"
+	paramCoverPackages      = "coverpkg"
 	paramDryRun             = "dry-run"
 	paramOutput             = "output"
 	paramIntegrationMode    = "integration"
@@ -186,6 +187,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 	fls := []*flags.Flag{
 		{Name: paramDryRun, CfgKey: configuration.UnleashDryRunKey, Shorthand: "d", DefaultV: false, Usage: "find mutations but do not executes tests"},
 		{Name: paramBuildTags, CfgKey: configuration.UnleashTagsKey, Shorthand: "t", DefaultV: "", Usage: "a comma-separated list of build tags"},
+		{Name: paramCoverPackages, CfgKey: configuration.UnleashCoverPkgKey, DefaultV: "", Usage: "a comma-separated list of package patterns"},
 		{Name: paramOutput, CfgKey: configuration.UnleashOutputKey, Shorthand: "o", DefaultV: "", Usage: "set the output file for machine readable results"},
 		{Name: paramIntegrationMode, CfgKey: configuration.UnleashIntegrationMode, Shorthand: "i", DefaultV: false, Usage: "makes Gremlins run the complete test suite for each mutation"},
 		{Name: paramThresholdEfficacy, CfgKey: configuration.UnleashThresholdEfficacyKey, DefaultV: float64(0), Usage: "threshold for code-efficacy percent"},

--- a/cmd/unleash_test.go
+++ b/cmd/unleash_test.go
@@ -61,6 +61,11 @@ func TestUnleash(t *testing.T) {
 			defValue: "true",
 		},
 		{
+			name:     "coverpkg",
+			flagType: "string",
+			defValue: "",
+		},
+		{
 			name:      "dry-run",
 			shorthand: "d",
 			flagType:  "bool",

--- a/docs/docs/schema/configuration.json
+++ b/docs/docs/schema/configuration.json
@@ -28,6 +28,15 @@
             "tag1,tag2,tag4"
           ]
         },
+        "coverpkg": {
+          "title": "Cover packages",
+          "description": "Apply coverage analysis in each test to packages matching the patterns",
+          "type": "string",
+          "default": "",
+          "examples": [
+            "./internal/log,./pkg/..."
+          ]
+        },
         "output": {
           "title": "Output",
           "description": "The output file for machine readable results",

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -49,6 +49,17 @@ Enables/disables the [CONDITIONALS NEGATION](../../mutations/conditionals_negati
 gremlins unleash --conditionals_negation=false
 ```
 
+### Cover packages
+
+:material-flag: `--coverpkg` · :material-sign-direction: Default: empty
+
+Apply coverage analysis in each test to packages matching the patterns.
+The default is for each test to analyze only the package being tested.
+
+```shell
+gremlins unleash --coverpkg "./internal/...,./pkg/..."
+```
+
 ### Dry run
 
 :material-flag:`--dry-run`/`-d` · :material-sign-direction: Default: false

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -36,6 +36,7 @@ const (
 	UnleashDryRunKey             = "unleash.dry-run"
 	UnleashOutputKey             = "unleash.output"
 	UnleashTagsKey               = "unleash.tags"
+	UnleashCoverPkgKey           = "unleash.coverpkg"
 	UnleashWorkersKey            = "unleash.workers"
 	UnleashTestCPUKey            = "unleash.test-cpu"
 	UnleashTimeoutCoefficientKey = "unleash.timeout-coefficient"

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -50,6 +50,7 @@ type Coverage struct {
 	mod        gomodule.GoModule
 
 	buildTags       string
+	coverPkg        string
 	integrationMode bool
 }
 
@@ -67,6 +68,7 @@ func New(workdir string, mod gomodule.GoModule, opts ...Option) *Coverage {
 // NewWithCmd instantiates a Coverage element given a custom execContext.
 func NewWithCmd(cmdContext execContext, workdir string, mod gomodule.GoModule, opts ...Option) *Coverage {
 	buildTags := configuration.Get[string](configuration.UnleashTagsKey)
+	coverPkg := configuration.Get[string](configuration.UnleashCoverPkgKey)
 	integrationMode := configuration.Get[bool](configuration.UnleashIntegrationMode)
 
 	c := &Coverage{
@@ -76,6 +78,7 @@ func NewWithCmd(cmdContext execContext, workdir string, mod gomodule.GoModule, o
 		fileName:        "coverage",
 		mod:             mod,
 		buildTags:       buildTags,
+		coverPkg:        coverPkg,
 		integrationMode: integrationMode,
 	}
 	for _, opt := range opts {
@@ -141,6 +144,9 @@ func (c *Coverage) executeCoverage() (time.Duration, error) {
 	args := []string{"test"}
 	if c.buildTags != "" {
 		args = append(args, "-tags", c.buildTags)
+	}
+	if c.coverPkg != "" {
+		args = append(args, "-coverpkg", c.coverPkg)
 	}
 
 	args = append(args, "-cover", "-coverprofile", c.filePath(), c.scanPath())

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -71,10 +71,12 @@ func TestCoverageRun(t *testing.T) {
 			intMode:  true,
 		},
 	}
+	coverpkg := "./internal/log,./pkg/..."
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			viper.Set(configuration.UnleashTagsKey, "tag1 tag2")
+			viper.Set(configuration.UnleashCoverPkgKey, coverpkg)
 			viper.Set(configuration.UnleashIntegrationMode, tc.intMode)
 			defer viper.Reset()
 
@@ -92,7 +94,8 @@ func TestCoverageRun(t *testing.T) {
 			_, _ = cov.Run()
 
 			firstWant := "go mod download"
-			secondWant := fmt.Sprintf("go test -tags tag1 tag2 -cover -coverprofile %v %s", wantFilePath, tc.wantPath)
+			secondWant := fmt.Sprintf("go test -tags tag1 tag2 -coverpkg %s -cover -coverprofile %v %s",
+				coverpkg, wantFilePath, tc.wantPath)
 
 			if len(holder.events) != 2 {
 				t.Fatal("expected two commands to be executed")


### PR DESCRIPTION
## Proposed changes

A flag --coverpkg is added to the unleash command. This is handed over to the call of "go test -cover", similar to flag --tags.

Resolves #162


<!-- 
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

## Types of changes

<!--
What types of changes does your code introduce to Gremlins?
Put an 'x' in the boxes that apply.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- 
Put an 'x' in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code. 
-->

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

<!-- 
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc... 
-->