### PR TITLE
Use GOTMPDIR env to clean all the go-build folders

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -147,7 +147,6 @@ type mutantExecutor struct {
 	dryRun            bool
 	integrationMode   bool
 	testCPU           int
-	goTmpDirEnv       string
 }
 
 // Start is the implementation of the workerpool.Executor definition and is the
@@ -167,8 +166,6 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 	if err != nil {
 		panic("error, this is temporary")
 	}
-
-	m.goTmpDirEnv = fmt.Sprintf("GOTMPDIR=" + filepath.Dir(rootDir))
 
 	workingDir := filepath.Join(rootDir, m.module.CallingDir)
 	m.mutant.SetWorkdir(workingDir)
@@ -204,7 +201,7 @@ func (m *mutantExecutor) runTests(pkg string) mutator.Status {
 	cmd := m.execContext(ctx, "go", m.getTestArgs(pkg)...)
 	cmd.Dir = m.mutant.Workdir()
 	cmd.Env = append(cmd.Env, os.Environ()...)
-	cmd.Env = append(cmd.Env, m.goTmpDirEnv)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOTMPDIR=%s", m.wdDealer.WorkDir()))
 
 	rel, err := run(cmd)
 	defer rel()

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -494,7 +493,7 @@ func TestMutatorRunWithCorrectEnvs(t *testing.T) {
 		executor.Start(w)
 		wg.Wait()
 
-		goTmpDirEnv := fmt.Sprintf("GOTMPDIR=%s", filepath.Dir(mut.Workdir()))
+		goTmpDirEnv := fmt.Sprintf("GOTMPDIR=%s", wdDealer.WorkDir())
 		actualGoTmpDir := ""
 		for _, v := range holder.cmd.Env {
 			if strings.HasPrefix(v, "GOTMPDIR=") {

--- a/internal/engine/stubs_test.go
+++ b/internal/engine/stubs_test.go
@@ -91,6 +91,8 @@ func (d dealerStub) Get(_ string) (string, error) {
 
 func (dealerStub) Clean() {}
 
+func (dealerStub) WorkDir() string { return "/tmp" }
+
 type executorDealerStub struct {
 	gotMutants []mutator.Mutator
 }

--- a/internal/engine/workdir/workdir.go
+++ b/internal/engine/workdir/workdir.go
@@ -87,6 +87,7 @@ func (cd *CachedDealer) Get(idf string) (string, error) {
 	return dstDir, nil
 }
 
+// WorkDir provides the root working directory.
 func (cd *CachedDealer) WorkDir() string {
 	return cd.workDir
 }

--- a/internal/engine/workdir/workdir.go
+++ b/internal/engine/workdir/workdir.go
@@ -37,6 +37,7 @@ import (
 type Dealer interface {
 	Get(idf string) (string, error)
 	Clean()
+	WorkDir() string
 }
 
 // CachedDealer is the implementation of the Dealer interface, responsible
@@ -84,6 +85,10 @@ func (cd *CachedDealer) Get(idf string) (string, error) {
 	cd.setCache(idf, dstDir)
 
 	return dstDir, nil
+}
+
+func (cd *CachedDealer) WorkDir() string {
+	return cd.workDir
 }
 
 // Clean frees all the cached folders and removes all of them from disk.

--- a/internal/engine/workdir/workdir_test.go
+++ b/internal/engine/workdir/workdir_test.go
@@ -245,6 +245,20 @@ func TestErrors(t *testing.T) {
 	})
 }
 
+func TestWorkDirReturnsTheRootWorkingDir(t *testing.T) {
+	srcDir := t.TempDir()
+	populateSrcDir(t, srcDir, 0)
+	wdDir := t.TempDir()
+
+	dealer := workdir.NewCachedDealer(wdDir, srcDir)
+	defer dealer.Clean()
+
+	rootWorkingDir := dealer.WorkDir()
+	if rootWorkingDir != wdDir {
+		t.Errorf("expected working dir to be %s, got: %s", wdDir, rootWorkingDir)
+	}
+}
+
 func BenchmarkDealerGet(b *testing.B) {
 	srcDir := b.TempDir()
 	populateSrcDir(b, srcDir, 5)


### PR DESCRIPTION
## Proposed changes

Closes #182. 

## Types of changes

<!--
What types of changes does your code introduce to Gremlins?
Put an 'x' in the boxes that apply.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- 
Put an 'x' in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code. 
-->

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The proposed PR is an idea to overcome the issue of not cleaning build folders when going into time out.
Writing the test it felt a bit awkward the way I got the root dir of our `wdDealer`. I think in writing this line: 
```go
goTmpDirEnv := fmt.Sprintf("GOTMPDIR=%s", filepath.Dir(mut.Workdir()))
```
I'm leaking implementation logic in our test.

So I was thinking of another way to get the same result in a cleaner way. We might add a new func in the `Dealer interface`  that returns the root working directory.
```go
type Dealer interface {
	Get(idf string) (string, error)
	WorkDir() string
	Clean()
}
```
Introduction the `WorkDir()` getter we can also refactor the implementation in just this 2 lines:
```go
	cmd.Env = append(cmd.Env, os.Environ()...)
	cmd.Env = append(cmd.Env, fmt.Sprintf("GOTMPDIR=" +m.wdDealer.WorkDir()))
```

WDYT? Should I do the proposed refactoring? Do you suggest other improvements/solutions? 
