### PR TITLE
Fix EfficacyThreshold and MutantCoverageThreshold check logic

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -233,14 +233,14 @@ func (r *reportStatus) assess(tEfficacy, rCoverage float64) error {
 	if et == 0 {
 		et = float64(configuration.Get[int](configuration.UnleashThresholdEfficacyKey))
 	}
-	if et > 0 && tEfficacy <= et {
+	if et > 0 && tEfficacy < et {
 		return execution.NewExitErr(execution.EfficacyThreshold)
 	}
 	ct := configuration.Get[float64](configuration.UnleashThresholdMCoverageKey)
 	if ct == 0 {
 		ct = float64(configuration.Get[int](configuration.UnleashThresholdMCoverageKey))
 	}
-	if ct > 0 && rCoverage <= ct {
+	if ct > 0 && rCoverage < ct {
 		return execution.NewExitErr(execution.MutantCoverageThreshold)
 	}
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/go-gremlins/gremlins/internal/execution"
 	"go/token"
 	"os"
 	"path/filepath"
@@ -33,6 +32,7 @@ import (
 	"github.com/hectane/go-acl"
 	"github.com/spf13/viper"
 
+	"github.com/go-gremlins/gremlins/internal/execution"
 	"github.com/go-gremlins/gremlins/internal/log"
 	"github.com/go-gremlins/gremlins/internal/mutator"
 	"github.com/go-gremlins/gremlins/internal/report"
@@ -287,10 +287,8 @@ func TestAssessment(t *testing.T) {
 				} else {
 					t.Errorf("expected err to be ExitError")
 				}
-			} else {
-				if err != nil {
-					t.Fatal("unexpected error")
-				}
+			} else if err != nil {
+				t.Fatal("unexpected error")
 			}
 		})
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/go-gremlins/gremlins/internal/execution"
 	"go/token"
 	"os"
 	"path/filepath"
@@ -38,7 +39,6 @@ import (
 	"github.com/go-gremlins/gremlins/internal/report/internal"
 
 	"github.com/go-gremlins/gremlins/internal/configuration"
-	"github.com/go-gremlins/gremlins/internal/execution"
 )
 
 var fakePosition = newPosition("aFolder/aFile.go", 3, 12)
@@ -275,19 +275,22 @@ func TestAssessment(t *testing.T) {
 
 			err := report.Do(data)
 
-			if tc.expectError && err == nil {
-				t.Fatal("expected an error")
-			}
-			if !tc.expectError {
-				return
-			}
-			var exitErr *execution.ExitError
-			if errors.As(err, &exitErr) {
-				if exitErr.ExitCode() == 0 {
-					t.Errorf("expected exit code to be different from 0, got %d", exitErr.ExitCode())
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				var exitErr *execution.ExitError
+				if errors.As(err, &exitErr) {
+					if exitErr.ExitCode() == 0 {
+						t.Errorf("expected exit code to be different from 0, got %d", exitErr.ExitCode())
+					}
+				} else {
+					t.Errorf("expected err to be ExitError")
 				}
 			} else {
-				t.Errorf("expected err to be ExitError")
+				if err != nil {
+					t.Fatal("unexpected error")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Proposed changes

Threshold checks should fail if they fall short of the required value (i.e., less than the threshold). However, if the actual value matches the threshold exactly (e.g., 100 out of 100), it should not be considered a failure. The threshold has been met, so no error should be reported.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`) - Some linter issues reported on non changed files for this fix 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A