### PR TITLE
fix: Windows NO_COVERAGE issue

### DIFF
--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -203,5 +203,5 @@ func (c *Coverage) removeModuleFromPath(p *cover.Profile) string {
 	path := strings.ReplaceAll(p.FileName, c.mod.Name+"/", "")
 	path, _ = filepath.Rel(c.mod.CallingDir, path)
 
-	return filepath.ToSlash(path) //normalize to slashes
+	return filepath.ToSlash(path) // normalize to slashes
 }

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -203,5 +203,5 @@ func (c *Coverage) removeModuleFromPath(p *cover.Profile) string {
 	path := strings.ReplaceAll(p.FileName, c.mod.Name+"/", "")
 	path, _ = filepath.Rel(c.mod.CallingDir, path)
 
-	return path
+	return filepath.ToSlash(path) //normalize to slashes
 }

--- a/internal/coverage/profile.go
+++ b/internal/coverage/profile.go
@@ -18,8 +18,6 @@ package coverage
 
 import (
 	"go/token"
-	"os"
-	"strings"
 )
 
 // Profile is implemented as a map holding a slice of Block per each filename.
@@ -27,11 +25,6 @@ type Profile map[string][]Block
 
 // IsCovered checks if the given token.Position is covered by the coverage Profile.
 func (p Profile) IsCovered(pos token.Position) bool {
-	// normalise path separators
-	if strings.ContainsRune(pos.Filename, '/') {
-		pos.Filename = strings.ReplaceAll(pos.Filename, "/", string(os.PathSeparator))
-	}
-
 	blocks, ok := p[pos.Filename]
 	if !ok {
 		return false

--- a/internal/coverage/profile.go
+++ b/internal/coverage/profile.go
@@ -18,6 +18,8 @@ package coverage
 
 import (
 	"go/token"
+	"os"
+	"strings"
 )
 
 // Profile is implemented as a map holding a slice of Block per each filename.
@@ -25,6 +27,11 @@ type Profile map[string][]Block
 
 // IsCovered checks if the given token.Position is covered by the coverage Profile.
 func (p Profile) IsCovered(pos token.Position) bool {
+	// normalise path separators
+	if strings.ContainsRune(pos.Filename, '/') {
+		pos.Filename = strings.ReplaceAll(pos.Filename, "/", string(os.PathSeparator))
+	}
+
 	blocks, ok := p[pos.Filename]
 	if !ok {
 		return false

--- a/internal/coverage/profile_test.go
+++ b/internal/coverage/profile_test.go
@@ -215,3 +215,21 @@ func TestIsCovered(t *testing.T) {
 		})
 	}
 }
+
+func TestIsCovered_PathsWithSlashes(t *testing.T) {
+    profile := coverage.Profile{
+        "internal/coverage/file.go": []coverage.Block{
+            {StartLine: 10, StartCol: 1, EndLine: 20, EndCol: 1},
+        },
+    }
+    
+    pos := token.Position{
+        Filename: "internal/coverage/file.go",
+        Line:     15,
+        Column:   5,
+    }
+    
+    if !profile.IsCovered(pos) {
+        t.Error("expected position to be covered")
+    }
+}

--- a/internal/coverage/profile_test.go
+++ b/internal/coverage/profile_test.go
@@ -189,7 +189,7 @@ func TestIsCovered(t *testing.T) {
 	for _, tc := range testCases {
 		tCase := tc
 		t.Run(tCase.name, func(t *testing.T) {
-			profile := coverage.Profile{
+			profile := coverage.Profile {
 				tCase.proFilename: {
 					{
 						StartLine: tCase.proStartL,

--- a/internal/engine/stubs_test.go
+++ b/internal/engine/stubs_test.go
@@ -18,6 +18,7 @@ package engine_test
 
 import (
 	"errors"
+	"fmt"
 	"go/token"
 	"io"
 	"os"
@@ -56,8 +57,15 @@ func viperReset() {
 
 func loadFixture(fixture, fromPackage string) (fstest.MapFS, gomodule.GoModule, func()) {
 	//nolint:gosec // test code reading test fixtures
-	f, _ := os.Open(fixture)
-	src, _ := io.ReadAll(f)
+	f, err := os.Open(fixture)
+	if err != nil {
+		panic(fmt.Sprintf("failed to open test fixture %s: %v", fixture, err))
+	}
+	src, err := io.ReadAll(f)
+	if err != nil {
+		_ = f.Close()
+		panic(fmt.Sprintf("failed to read test fixture %s: %v", fixture, err))
+	}
 	filename := filenameFromFixture(fixture)
 	mapFS := fstest.MapFS{
 		filename: {Data: src},
@@ -73,8 +81,6 @@ func loadFixture(fixture, fromPackage string) (fstest.MapFS, gomodule.GoModule, 
 }
 
 func filenameFromFixture(fix string) string {
-	// Replace the path separator with the OS specific one.
-	fix = strings.ReplaceAll(fix, "/", string(os.PathSeparator))
 	return strings.ReplaceAll(fix, "_go", ".go")
 }
 

--- a/internal/engine/stubs_test.go
+++ b/internal/engine/stubs_test.go
@@ -73,6 +73,8 @@ func loadFixture(fixture, fromPackage string) (fstest.MapFS, gomodule.GoModule, 
 }
 
 func filenameFromFixture(fix string) string {
+	// Replace the path separator with the OS specific one.
+	fix = strings.ReplaceAll(fix, "/", string(os.PathSeparator))
 	return strings.ReplaceAll(fix, "_go", ".go")
 }
 


### PR DESCRIPTION
## Proposed changes

This PR fixes #222 

Root Cause: Path separators were not handled properly, which resulted in Windows coverage always calculated as NOT COVERED for all mutants

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None