### PR TITLE
chore: update goreleaser to v2 and fix deprecated settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: release --rm-dist
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
   documentation:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,7 +92,7 @@ brews:
       name: homebrew-tap
       branch: main
       token: "{{ .Env.GITHUB_TOKEN }}"
-    folder: Formula
+    directory: Formula
     homepage: https://gremlins.dev
     description: A mutation testing tool for Go.
     license: Apache-2.0 License
@@ -104,7 +104,7 @@ checksum:
 source:
   enabled: true
 changelog:
-  skip: false
+  disable: false
   sort: asc
   use: github-native
 snapshot:


### PR DESCRIPTION
## Summary
- Update goreleaser-action to v6
- Update goreleaser version from `latest` to `~> v2` (v2.13.0)
- Fix deprecated `--rm-dist` flag → `--clean`
- Fix deprecated `brews.folder` → `brews.directory`
- Fix deprecated `changelog.skip` → `changelog.disable`

## Motivation
Goreleaser v0.6.0 release failed due to deprecated settings and the `--rm-dist` flag being removed in v2.

## Testing
Will be tested when the next release tag is pushed.