### PR TITLE
fix(engine): improve error reporting in workdir panic

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -162,7 +162,8 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 	workerName := fmt.Sprintf("%s-%d", w.Name, w.ID)
 	rootDir, err := m.wdDealer.Get(workerName)
 	if err != nil {
-		panic("error, this is temporary")
+		log.Errorf("failed to get working directory for worker %s: %v", workerName, err)
+		panic(fmt.Sprintf("failed to get working directory for worker %s: %v", workerName, err))
 	}
 
 	workingDir := filepath.Join(rootDir, m.module.CallingDir)


### PR DESCRIPTION
## Summary
Fixes #213 by replacing the unhelpful panic message "error, this is temporary" with proper error reporting.

## Changes
- Added error logging before panic using `log.Errorf` with full context (worker name and error details)
- Updated panic message to include the actual error and worker name
- Follows the error handling pattern used elsewhere in the file (see line 177-180)

## Test plan
- [x] All existing tests pass
- [x] No linting issues
- Manual verification: Error message now provides debugging information when workdir dealer fails

Closes #213