### PR TITLE
feat: add output mutation diff

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -27,18 +27,17 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/go-gremlins/gremlins/cmd/internal/flags"
+	"github.com/go-gremlins/gremlins/internal/configuration"
 	"github.com/go-gremlins/gremlins/internal/coverage"
 	"github.com/go-gremlins/gremlins/internal/diff"
 	"github.com/go-gremlins/gremlins/internal/engine"
 	"github.com/go-gremlins/gremlins/internal/engine/workdir"
 	"github.com/go-gremlins/gremlins/internal/exclusion"
+	"github.com/go-gremlins/gremlins/internal/gomodule"
 	"github.com/go-gremlins/gremlins/internal/log"
 	"github.com/go-gremlins/gremlins/internal/mutator"
 	"github.com/go-gremlins/gremlins/internal/report"
-
-	"github.com/go-gremlins/gremlins/cmd/internal/flags"
-	"github.com/go-gremlins/gremlins/internal/configuration"
-	"github.com/go-gremlins/gremlins/internal/gomodule"
 )
 
 type unleashCmd struct {
@@ -53,6 +52,7 @@ const (
 	paramCoverPackages      = "coverpkg"
 	paramDryRun             = "dry-run"
 	paramOutputStatuses     = "output-statuses"
+	paramOutputDiffStatuses = "output-diff-statuses"
 	paramOutput             = "output"
 	paramIntegrationMode    = "integration"
 	paramExcludeFiles       = "exclude-files"
@@ -208,6 +208,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 	fls := []*flags.Flag{
 		{Name: paramDryRun, CfgKey: configuration.UnleashDryRunKey, Shorthand: "d", DefaultV: false, Usage: "find mutations but do not executes tests"},
 		{Name: paramOutputStatuses, CfgKey: configuration.UnleashOutputStatusesKey, Shorthand: "S", DefaultV: "", Usage: "print only statuses from this flag, allowed values - 'lctkvsr'"},
+		{Name: paramOutputDiffStatuses, CfgKey: configuration.UnleashOutputDiffStatusesKey, DefaultV: "", Usage: "print diff for mutants with these statuses, allowed values - 'lk'"},
 		{Name: paramBuildTags, CfgKey: configuration.UnleashTagsKey, Shorthand: "t", DefaultV: "", Usage: "a comma-separated list of build tags"},
 		{Name: paramCoverPackages, CfgKey: configuration.UnleashCoverPkgKey, DefaultV: "", Usage: "a comma-separated list of package patterns"},
 		{Name: paramDiff, CfgKey: configuration.UnleashDiffRef, Shorthand: "D", DefaultV: "", Usage: "diff branch or commit"},

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -166,6 +166,44 @@ Output
 - `s` - SKIPPED
 - `r` - RUNNABLE
 
+### Diff statuses output
+
+:material-flag: `--output-diff-statuses` · :material-sign-direction: Default: empty - no diffs shown
+
+Prints a unified diff of the original vs mutated code snippet for mutants whose status matches
+the filter. Only `l` (LIVED) and `k` (KILLED) are accepted — other statuses are not valid because
+diffs are only meaningful for mutants that were actually executed and had their source changed.
+
+This flag works in combination with `--output-statuses`: a mutant that is hidden by
+`--output-statuses` will produce no output at all — no status line and no diff.
+
+#### Examples
+
+##### Show diff for survived mutants
+
+```shell
+gremlins unleash --output-diff-statuses l
+```
+
+Output
+
+```
+       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3
+       -x > y
+       +x >= y
+```
+
+##### Show diff for both lived and killed mutants
+
+```shell
+gremlins unleash --output-diff-statuses lk
+```
+
+### Filter letters
+
+- `l` - LIVED
+- `k` - KILLED
+
 ### Increment decrement
 
 :material-flag: `--increment-decrement` · :material-sign-direction: Default: `true`

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/fatih/color v1.18.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
+github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bluekeyes/go-gitdiff v0.8.1 h1:lL1GofKMywO17c0lgQmJYcKek5+s8X6tXVNOLxy4smI=
 github.com/bluekeyes/go-gitdiff v0.8.1/go.mod h1:WWAk1Mc6EgWarCrPFO+xeYlujPu98VuLW3Tu+B/85AE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -47,6 +47,7 @@ const (
 	UnleashDiffRef               = "unleash.diff"
 	UnleashThresholdEfficacyKey  = "unleash.threshold.efficacy"
 	UnleashThresholdMCoverageKey = "unleash.threshold.mutant-coverage"
+	UnleashOutputDiffStatusesKey = "unleash.output-diff-statuses"
 )
 
 const (

--- a/internal/engine/stubs_test.go
+++ b/internal/engine/stubs_test.go
@@ -190,3 +190,11 @@ func (m *mutantStub) Rollback() error {
 
 	return nil
 }
+
+func (m *mutantStub) OrigSnippet() []byte {
+	return nil
+}
+
+func (m *mutantStub) MutatedSnippet() []byte {
+	return nil
+}

--- a/internal/engine/stubs_test.go
+++ b/internal/engine/stubs_test.go
@@ -191,10 +191,10 @@ func (m *mutantStub) Rollback() error {
 	return nil
 }
 
-func (m *mutantStub) OrigSnippet() []byte {
+func (*mutantStub) OrigSnippet() []byte {
 	return nil
 }
 
-func (m *mutantStub) MutatedSnippet() []byte {
+func (*mutantStub) MutatedSnippet() []byte {
 	return nil
 }

--- a/internal/engine/tokenmutator.go
+++ b/internal/engine/tokenmutator.go
@@ -48,6 +48,9 @@ type TokenMutator struct {
 	status      mutator.Status
 	mutantType  mutator.Type
 	actualToken token.Token
+
+	origSnippet    []byte
+	mutatedSnippet []byte
 }
 
 // NewTokenMutant initialises a TokenMutator.
@@ -116,6 +119,8 @@ func (m *TokenMutator) Apply() error {
 		return err
 	}
 
+	m.origSnippet = extractSnippet(m.origFile, m.Position().Line, 3)
+
 	m.actualToken = m.tokenNode.Tok()
 	m.tokenNode.SetTok(tokenMutations[m.Type()][m.tokenNode.Tok()])
 
@@ -136,16 +141,22 @@ func (m *TokenMutator) writeMutatedFile(filename string) error {
 		return err
 	}
 
-	err = os.WriteFile(filename, w.Bytes(), 0600)
+	payload := w.Bytes()
+
+	err = os.WriteFile(filename, payload, 0o600)
 	if err != nil {
 		return err
 	}
 
+	m.mutatedSnippet = extractSnippet(payload, m.Position().Line, 3)
+
 	return nil
 }
 
-var locks = make(map[string]*sync.Mutex)
-var mutex sync.RWMutex
+var (
+	locks = make(map[string]*sync.Mutex)
+	mutex sync.RWMutex
+)
 
 func fileLock(filename string) *sync.Mutex {
 	lock, ok := cachedLock(filename)
@@ -180,7 +191,7 @@ func (m *TokenMutator) Rollback() error {
 	defer m.resetOrigFile()
 	filename := filepath.Join(m.workDir, m.Position().Filename)
 
-	return os.WriteFile(filename, m.origFile, 0600)
+	return os.WriteFile(filename, m.origFile, 0o600)
 }
 
 // SetWorkdir sets the base path on which to Apply and Rollback operations.
@@ -200,4 +211,31 @@ func (m *TokenMutator) Workdir() string {
 func (m *TokenMutator) resetOrigFile() {
 	var zeroByte []byte
 	m.origFile = zeroByte
+}
+
+// OrigSnippet returns the original code snippet around the mutation point.
+func (m *TokenMutator) OrigSnippet() []byte {
+	return m.origSnippet
+}
+
+// MutatedSnippet returns the mutated code snippet around the mutation point.
+func (m *TokenMutator) MutatedSnippet() []byte {
+	return m.mutatedSnippet
+}
+
+// extractSnippet extracts lines around the target line with the given context size.
+func extractSnippet(content []byte, targetLine, contextLines int) []byte {
+	lines := bytes.Split(content, []byte("\n"))
+
+	start := targetLine - contextLines - 1
+	if start < 0 {
+		start = 0
+	}
+
+	end := targetLine + contextLines
+	if end > len(lines) {
+		end = len(lines)
+	}
+
+	return bytes.Join(lines[start:end], []byte("\n"))
 }

--- a/internal/engine/tokenmutator.go
+++ b/internal/engine/tokenmutator.go
@@ -237,5 +237,9 @@ func extractSnippet(content []byte, targetLine, contextLines int) []byte {
 		end = len(lines)
 	}
 
+	if start > end {
+		start = end
+	}
+
 	return bytes.Join(lines[start:end], []byte("\n"))
 }

--- a/internal/engine/tokenmutator_internal_test.go
+++ b/internal/engine/tokenmutator_internal_test.go
@@ -73,6 +73,12 @@ func TestExtractSnippet(t *testing.T) {
 			contextLines: 3,
 			want:         []byte(""),
 		},
+		"should_return_empty_when_target_line_is_beyond_content": {
+			content:      []byte("line1\nline2\nline3"),
+			targetLine:   20,
+			contextLines: 3,
+			want:         []byte(""),
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/engine/tokenmutator_internal_test.go
+++ b/internal/engine/tokenmutator_internal_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractSnippet(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		content      []byte
+		targetLine   int
+		contextLines int
+		want         []byte
+	}{
+		"should_clamp_start_to_zero_when_target_line_is_near_beginning": {
+			content:      []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10"),
+			targetLine:   1,
+			contextLines: 3,
+			want:         []byte("line1\nline2\nline3\nline4"),
+		},
+		"should_extract_lines_around_target_when_target_is_in_the_middle": {
+			content:      []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10"),
+			targetLine:   5,
+			contextLines: 2,
+			want:         []byte("line3\nline4\nline5\nline6\nline7"),
+		},
+		"should_clamp_end_to_content_length_when_target_line_is_near_end": {
+			content:      []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10"),
+			targetLine:   9,
+			contextLines: 3,
+			want:         []byte("line6\nline7\nline8\nline9\nline10"),
+		},
+		"should_return_all_content_when_context_is_larger_than_file": {
+			content:      []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10"),
+			targetLine:   5,
+			contextLines: 20,
+			want:         []byte("line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10"),
+		},
+		"should_handle_trailing_newline_in_content": {
+			content:      []byte("line1\nline2\nline3\n"),
+			targetLine:   2,
+			contextLines: 1,
+			want:         []byte("line1\nline2\nline3"),
+		},
+		"should_return_only_target_line_when_context_is_zero": {
+			content:      []byte("line1\nline2\nline3"),
+			targetLine:   2,
+			contextLines: 0,
+			want:         []byte("line2"),
+		},
+		"should_return_empty_when_content_is_empty": {
+			content:      []byte(""),
+			targetLine:   1,
+			contextLines: 3,
+			want:         []byte(""),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if diff := cmp.Diff(string(tc.want), string(extractSnippet(tc.content, tc.targetLine, tc.contextLines))); diff != "" {
+				t.Errorf("extractSnippet() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/engine/tokenmutator_test.go
+++ b/internal/engine/tokenmutator_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestTokenMutator_Apply_SetsSnippets(t *testing.T) {
+	t.Parallel()
+
 	src := "package main\n\nfunc main() {\n\ta := 1 + 2\n}\n"
 
 	testCases := map[string]struct {

--- a/internal/engine/tokenmutator_test.go
+++ b/internal/engine/tokenmutator_test.go
@@ -30,6 +30,86 @@ import (
 	"github.com/go-gremlins/gremlins/internal/mutator"
 )
 
+func TestTokenMutator_Apply_SetsSnippets(t *testing.T) {
+	src := "package main\n\nfunc main() {\n\ta := 1 + 2\n}\n"
+
+	testCases := map[string]struct {
+		assertFunc func(t *testing.T, mut *engine.TokenMutator, err error)
+	}{
+		"should_set_orig_snippet_when_apply_is_called": {
+			assertFunc: func(t *testing.T, mut *engine.TokenMutator, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []byte("package main\n\nfunc main() {\n\ta := 1 + 2\n}\n")
+				if !cmp.Equal(want, mut.OrigSnippet()) {
+					t.Fatal(cmp.Diff(string(want), string(mut.OrigSnippet())))
+				}
+			},
+		},
+		"should_set_mutated_snippet_when_apply_is_called": {
+			assertFunc: func(t *testing.T, mut *engine.TokenMutator, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := []byte("package main\n\nfunc main() {\n\ta := 1 - 2\n}\n")
+				if !cmp.Equal(want, mut.MutatedSnippet()) {
+					t.Fatal(cmp.Diff(string(want), string(mut.MutatedSnippet())))
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			workdir := t.TempDir()
+			filePath := "sourceFile.go"
+			fileFullPath := filepath.Join(workdir, filePath)
+
+			err := os.WriteFile(fileFullPath, []byte(src), 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			set := token.NewFileSet()
+			f, err := parser.ParseFile(set, filePath, src, parser.ParseComments)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var node *ast.BinaryExpr
+			ast.Inspect(f, func(n ast.Node) bool {
+				if b, ok := n.(*ast.BinaryExpr); ok && node == nil {
+					node = b
+				}
+
+				return true
+			})
+			if node == nil {
+				t.Fatal("binary expression node must be found")
+			}
+
+			n, ok := engine.NewTokenNode(node)
+			if !ok {
+				t.Fatal("token node must be created")
+			}
+
+			mut := engine.NewTokenMutant("example.com/test", set, f, n)
+			mut.SetType(mutator.ArithmeticBase)
+			mut.SetStatus(mutator.Runnable)
+			mut.SetWorkdir(workdir)
+
+			applyErr := mut.Apply()
+
+			tc.assertFunc(t, mut, applyErr)
+		})
+	}
+}
+
 func TestMutantApplyAndRollback(t *testing.T) {
 	want := []string{
 		"package main\n\nfunc main() {\n\ta := 1 - 2\n\tb := 1 - 2\n}\n",
@@ -41,7 +121,7 @@ func TestMutantApplyAndRollback(t *testing.T) {
 	filePath := "sourceFile.go"
 	fileFullPath := filepath.Join(workdir, filePath)
 
-	err := os.WriteFile(fileFullPath, []byte(rollbackWant), 0600)
+	err := os.WriteFile(fileFullPath, []byte(rollbackWant), 0o600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/workerpool/workerpool_test.go
+++ b/internal/engine/workerpool/workerpool_test.go
@@ -203,3 +203,11 @@ func (fakeMutant) Apply() error {
 func (fakeMutant) Rollback() error {
 	panic("not used in test")
 }
+
+func (fakeMutant) OrigSnippet() []byte {
+	panic("not used in test")
+}
+
+func (fakeMutant) MutatedSnippet() []byte {
+	panic("not used in test")
+}

--- a/internal/mutator/mutator.go
+++ b/internal/mutator/mutator.go
@@ -169,4 +169,10 @@ type Mutator interface {
 	// Rollback removes the mutation from the source code and sets it back to
 	// its original status.
 	Rollback() error
+
+	// OrigSnippet returns the original code snippet around the mutation point.
+	OrigSnippet() []byte
+
+	// MutatedSnippet returns the mutated code snippet around the mutation point.
+	MutatedSnippet() []byte
 }

--- a/internal/report/logger.go
+++ b/internal/report/logger.go
@@ -15,9 +15,13 @@ type Filter = map[mutator.Status]struct{}
 // ErrInvalidFilter is returned when an invalid status filter string is provided.
 var ErrInvalidFilter = errors.New("invalid statuses filter, only 'lctkvsr' letters allowed")
 
+// ErrInvalidDiffFilter is returned when an invalid diff status filter string is provided.
+var ErrInvalidDiffFilter = errors.New("invalid statuses diff, only 'lk' letters allowed")
+
 // MutantLogger prints mutant statuses based on filter and verbosity flags.
 type MutantLogger struct {
 	Filter
+	DiffFilter Filter
 }
 
 // NewLogger creates a new MutantLogger with filters from configuration.
@@ -28,21 +32,30 @@ func NewLogger() MutantLogger {
 		log.Infof("output-statuses filter not applied: %s\n", err)
 	}
 
+	diffStatuses := configuration.Get[string](configuration.UnleashOutputDiffStatusesKey)
+	df, err := ParseDiffFilter(diffStatuses)
+	if err != nil {
+		log.Infof("output-diff-statuses filter not applied: %s\n", err)
+	}
+
 	return MutantLogger{
-		Filter: f,
+		Filter:     f,
+		DiffFilter: df,
 	}
 }
 
-// Mutant logs a mutant if it passes the filter.
+// Mutant logs a mutant if it passes the filter, then optionally prints the diff.
 func (l MutantLogger) Mutant(m mutator.Mutator) {
-	if l.Filter == nil {
-		Mutant(m)
-
-		return
+	if l.Filter != nil {
+		if _, ok := l.Filter[m.Status()]; !ok {
+			return
+		}
 	}
 
-	if _, ok := l.Filter[m.Status()]; ok {
-		Mutant(m)
+	Mutant(m)
+
+	if _, ok := l.DiffFilter[m.Status()]; ok {
+		MutantDiff(m)
 	}
 }
 
@@ -73,6 +86,29 @@ func ParseFilter(s string) (Filter, error) {
 			result[mutator.Runnable] = struct{}{}
 		default:
 			return nil, ErrInvalidFilter
+		}
+	}
+
+	return result, nil
+}
+
+// ParseDiffFilter parses a diff status filter string into a Filter map.
+// Valid characters are 'l' and 'k' representing Lived and Killed statuses.
+func ParseDiffFilter(s string) (Filter, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	result := Filter{}
+
+	for _, r := range s {
+		switch r {
+		case 'l':
+			result[mutator.Lived] = struct{}{}
+		case 'k':
+			result[mutator.Killed] = struct{}{}
+		default:
+			return nil, ErrInvalidDiffFilter
 		}
 	}
 

--- a/internal/report/logger_test.go
+++ b/internal/report/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -104,4 +105,64 @@ func TestLogger(t *testing.T) {
 	if !cmp.Equal(got, want) {
 		t.Error(cmp.Diff(got, want))
 	}
+}
+
+func TestLoggerOutputDiffStatuses(t *testing.T) {
+	livedWithSnippets := stubMutant{
+		status:         mutator.Lived,
+		mutantType:     mutator.ConditionalsBoundary,
+		position:       fakePosition,
+		originSnippet:  []byte("x > y\n"),
+		mutatedSnippet: []byte("x >= y\n"),
+	}
+	statusLine := "       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+
+	t.Run("prints diff when status matches output-diff-statuses", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		log.Init(out, &bytes.Buffer{})
+		defer log.Reset()
+		configuration.Set(configuration.UnleashOutputDiffStatusesKey, "l")
+		defer configuration.Reset()
+
+		logger := report.NewLogger()
+		logger.Mutant(livedWithSnippets)
+
+		got := out.String()
+		if !strings.HasPrefix(got, statusLine) {
+			t.Errorf("expected status line prefix, got: %q", got)
+		}
+		if !strings.Contains(got, "-x > y") || !strings.Contains(got, "+x >= y") {
+			t.Errorf("expected diff lines in output, got: %q", got)
+		}
+	})
+
+	t.Run("does not print diff when status does not match output-diff-statuses", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		log.Init(out, &bytes.Buffer{})
+		defer log.Reset()
+		configuration.Set(configuration.UnleashOutputDiffStatusesKey, "k")
+		defer configuration.Reset()
+
+		logger := report.NewLogger()
+		logger.Mutant(livedWithSnippets)
+
+		got := out.String()
+		if got != statusLine {
+			t.Errorf("expected only status line, got: %q", got)
+		}
+	})
+
+	t.Run("does not print diff when output-diff-statuses is not set", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		log.Init(out, &bytes.Buffer{})
+		defer log.Reset()
+
+		logger := report.NewLogger()
+		logger.Mutant(livedWithSnippets)
+
+		got := out.String()
+		if got != statusLine {
+			t.Errorf("expected only status line, got: %q", got)
+		}
+	})
 }

--- a/internal/report/logger_test.go
+++ b/internal/report/logger_test.go
@@ -66,6 +66,115 @@ func Test_parseFilter(t *testing.T) {
 	}
 }
 
+func TestParseDiffFilter(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input      string
+		assertFunc func(t *testing.T, got report.Filter, err error)
+	}{
+		"should_return_nil_when_input_is_empty": {
+			input: "",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				if got != nil {
+					t.Errorf("expected nil filter, got: %v", got)
+				}
+			},
+		},
+		"should_return_error_when_input_contains_invalid_character": {
+			input: "x",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if !errors.Is(err, report.ErrInvalidDiffFilter) {
+					t.Errorf("expected ErrInvalidDiffFilter, got: %v", err)
+				}
+				if got != nil {
+					t.Errorf("expected nil filter on error, got: %v", got)
+				}
+			},
+		},
+		"should_return_error_when_invalid_character_is_mixed_with_valid": {
+			input: "lx",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if !errors.Is(err, report.ErrInvalidDiffFilter) {
+					t.Errorf("expected ErrInvalidDiffFilter, got: %v", err)
+				}
+				if got != nil {
+					t.Errorf("expected nil filter on error, got: %v", got)
+				}
+			},
+		},
+		"should_return_filter_with_lived_when_input_is_l": {
+			input: "l",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				want := report.Filter{mutator.Lived: struct{}{}}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
+				}
+			},
+		},
+		"should_return_filter_with_killed_when_input_is_k": {
+			input: "k",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				want := report.Filter{mutator.Killed: struct{}{}}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
+				}
+			},
+		},
+		"should_return_filter_with_both_statuses_when_input_is_lk": {
+			input: "lk",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				want := report.Filter{
+					mutator.Lived:  struct{}{},
+					mutator.Killed: struct{}{},
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
+				}
+			},
+		},
+		"should_deduplicate_repeated_characters": {
+			input: "ll",
+			assertFunc: func(t *testing.T, got report.Filter, err error) {
+				t.Helper()
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				want := report.Filter{mutator.Lived: struct{}{}}
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := report.ParseDiffFilter(tc.input)
+			tc.assertFunc(t, got, err)
+		})
+	}
+}
+
 func TestLogger(t *testing.T) {
 	out := &bytes.Buffer{}
 	defer out.Reset()

--- a/internal/report/logger_test.go
+++ b/internal/report/logger_test.go
@@ -160,6 +160,65 @@ func TestLogger(t *testing.T) {
 	}
 }
 
+func TestLoggerOutputStatusesAndDiffStatusesTogether(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mutant filtered by output-statuses produces no output at all, even if diff-statuses would match", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		errOut := &bytes.Buffer{}
+		log.Init(out, errOut)
+		defer log.Reset()
+
+		configuration.Set(configuration.UnleashOutputStatusesKey, "k")
+		configuration.Set(configuration.UnleashOutputDiffStatusesKey, "l")
+		defer configuration.Reset()
+
+		logger := report.NewLogger()
+		logger.Mutant(stubMutant{
+			status:         mutator.Lived,
+			mutantType:     mutator.ConditionalsBoundary,
+			position:       fakePosition,
+			originSnippet:  []byte("x > y\n"),
+			mutatedSnippet: []byte("x >= y\n"),
+		})
+
+		if out.Len() > 0 {
+			t.Errorf("expected no output for filtered-out mutant, got: %q", out.String())
+		}
+		if errOut.Len() > 0 {
+			t.Errorf("expected no error output for filtered-out mutant, got: %q", errOut.String())
+		}
+	})
+
+	t.Run("mutant passing output-statuses filter prints status and diff when diff-statuses matches", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		log.Init(out, &bytes.Buffer{})
+		defer log.Reset()
+
+		configuration.Set(configuration.UnleashOutputStatusesKey, "k")
+		configuration.Set(configuration.UnleashOutputDiffStatusesKey, "k")
+		defer configuration.Reset()
+
+		logger := report.NewLogger()
+		logger.Mutant(stubMutant{
+			status:         mutator.Killed,
+			mutantType:     mutator.ConditionalsBoundary,
+			position:       fakePosition,
+			originSnippet:  []byte("x > y\n"),
+			mutatedSnippet: []byte("x >= y\n"),
+		})
+
+		got := out.String()
+		statusLine := "      KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		if !strings.HasPrefix(got, statusLine) {
+			t.Errorf("expected status line prefix, got: %q", got)
+		}
+		if !strings.Contains(got, "-x > y") || !strings.Contains(got, "+x >= y") {
+			t.Errorf("expected diff lines in output, got: %q", got)
+		}
+	})
+}
+
 func TestLoggerOutputDiffStatuses(t *testing.T) {
 	livedWithSnippets := stubMutant{
 		status:         mutator.Lived,

--- a/internal/report/logger_test.go
+++ b/internal/report/logger_test.go
@@ -161,8 +161,6 @@ func TestLogger(t *testing.T) {
 }
 
 func TestLoggerOutputStatusesAndDiffStatusesTogether(t *testing.T) {
-	t.Parallel()
-
 	t.Run("mutant filtered by output-statuses produces no output at all, even if diff-statuses would match", func(t *testing.T) {
 		out := &bytes.Buffer{}
 		errOut := &bytes.Buffer{}

--- a/internal/report/logger_test.go
+++ b/internal/report/logger_test.go
@@ -71,106 +71,50 @@ func TestParseDiffFilter(t *testing.T) {
 
 	testCases := map[string]struct {
 		input      string
-		assertFunc func(t *testing.T, got report.Filter, err error)
+		wantFilter report.Filter
+		wantErr    error
 	}{
 		"should_return_nil_when_input_is_empty": {
 			input: "",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				if got != nil {
-					t.Errorf("expected nil filter, got: %v", got)
-				}
-			},
 		},
 		"should_return_error_when_input_contains_invalid_character": {
-			input: "x",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if !errors.Is(err, report.ErrInvalidDiffFilter) {
-					t.Errorf("expected ErrInvalidDiffFilter, got: %v", err)
-				}
-				if got != nil {
-					t.Errorf("expected nil filter on error, got: %v", got)
-				}
-			},
+			input:   "x",
+			wantErr: report.ErrInvalidDiffFilter,
 		},
 		"should_return_error_when_invalid_character_is_mixed_with_valid": {
-			input: "lx",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if !errors.Is(err, report.ErrInvalidDiffFilter) {
-					t.Errorf("expected ErrInvalidDiffFilter, got: %v", err)
-				}
-				if got != nil {
-					t.Errorf("expected nil filter on error, got: %v", got)
-				}
-			},
+			input:   "lx",
+			wantErr: report.ErrInvalidDiffFilter,
 		},
 		"should_return_filter_with_lived_when_input_is_l": {
-			input: "l",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				want := report.Filter{mutator.Lived: struct{}{}}
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
-				}
-			},
+			input:      "l",
+			wantFilter: report.Filter{mutator.Lived: struct{}{}},
 		},
 		"should_return_filter_with_killed_when_input_is_k": {
-			input: "k",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				want := report.Filter{mutator.Killed: struct{}{}}
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
-				}
-			},
+			input:      "k",
+			wantFilter: report.Filter{mutator.Killed: struct{}{}},
 		},
 		"should_return_filter_with_both_statuses_when_input_is_lk": {
-			input: "lk",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				want := report.Filter{
-					mutator.Lived:  struct{}{},
-					mutator.Killed: struct{}{},
-				}
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
-				}
-			},
+			input:      "lk",
+			wantFilter: report.Filter{mutator.Lived: struct{}{}, mutator.Killed: struct{}{}},
 		},
 		"should_deduplicate_repeated_characters": {
-			input: "ll",
-			assertFunc: func(t *testing.T, got report.Filter, err error) {
-				t.Helper()
-				if err != nil {
-					t.Errorf("expected no error, got: %v", err)
-				}
-				want := report.Filter{mutator.Lived: struct{}{}}
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("ParseDiffFilter() got = %v, want %v", got, want)
-				}
-			},
+			input:      "ll",
+			wantFilter: report.Filter{mutator.Lived: struct{}{}},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
 			got, err := report.ParseDiffFilter(tc.input)
-			tc.assertFunc(t, got, err)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("expected err %v, got: %v", tc.wantErr, err)
+			}
+
+			if !reflect.DeepEqual(got, tc.wantFilter) {
+				t.Errorf("ParseDiffFilter() got = %v, want %v", got, tc.wantFilter)
+			}
 		})
 	}
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -328,7 +328,7 @@ func generateDiff(m mutator.Mutator) ([]string, error) {
 	// --- Original
 	// +++ Mutated
 	// @@ -1 +1 @@
-	for _, line := range lines[3:] {
+	for _, line := range lines {
 		switch {
 		case line == "":
 		case strings.HasPrefix(line, "---"):

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -18,18 +18,21 @@ package report
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/aymanbagabas/go-udiff"
 	"github.com/fatih/color"
 	"github.com/hako/durafmt"
 
+	"github.com/go-gremlins/gremlins/internal/configuration"
+	"github.com/go-gremlins/gremlins/internal/execution"
 	"github.com/go-gremlins/gremlins/internal/log"
 	"github.com/go-gremlins/gremlins/internal/mutator"
 	"github.com/go-gremlins/gremlins/internal/report/internal"
-
-	"github.com/go-gremlins/gremlins/internal/configuration"
-	"github.com/go-gremlins/gremlins/internal/execution"
 )
 
 var (
@@ -70,7 +73,6 @@ type reportStatus struct {
 
 func newReport(results Results) (*reportStatus, bool) {
 	if len(results.Mutants) == 0 {
-
 		return nil, false
 	}
 	rep := &reportStatus{
@@ -284,6 +286,66 @@ func Mutant(m mutator.Mutator) {
 		status = fgHiBlack(m.Status())
 	}
 	log.Infof("%s%s %s at %s\n", padding(m.Status()), status, m.Type(), m.Position())
+}
+
+// MutantDiff logs the unified diff between the original and mutated code snippets.
+// This function uses the log package in gremlins to write to the
+// chosen io.Writer, so it is necessary to call log.Init before
+// the report generation.
+func MutantDiff(m mutator.Mutator) {
+	diff, err := generateDiff(m)
+	if err != nil {
+		log.Errorf("failed to generate diff for mutant: %s", err.Error())
+
+		return
+	}
+	for _, line := range diff {
+		log.Infof("%s%s\n", padding(m.Status()), line)
+	}
+}
+
+// generateDiff returns a colored unified diff string for a survived mutant,
+// or an empty string if no diff is available.
+func generateDiff(m mutator.Mutator) ([]string, error) {
+	original := m.OrigSnippet()
+	mutated := m.MutatedSnippet()
+	if len(original) == 0 || len(mutated) == 0 {
+		return nil, errors.New("no differences found")
+	}
+
+	diffText, err := udiff.ToUnified("Original", "Mutated", string(original), udiff.Bytes(original, mutated), 3)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate diff: %w", err)
+	}
+
+	lines := strings.Split(diffText, "\n")
+	if len(lines) <= 3 {
+		return nil, nil
+	}
+
+	diffBuilder := make([]string, 0, len(lines)-3)
+	// Skip lines until the actual diff content starts
+	// --- Original
+	// +++ Mutated
+	// @@ -1 +1 @@
+	for _, line := range lines[3:] {
+		switch {
+		case line == "":
+		case strings.HasPrefix(line, "---"):
+		case strings.HasPrefix(line, "+++"):
+		case strings.HasPrefix(line, "@@"):
+		case strings.Contains(line, "No newline at end of file"):
+			continue
+		case strings.HasPrefix(line, "-"):
+			diffBuilder = append(diffBuilder, fgRed(line))
+		case strings.HasPrefix(line, "+"):
+			diffBuilder = append(diffBuilder, fgGreen(line))
+		default:
+			diffBuilder = append(diffBuilder, fgHiBlack(line))
+		}
+	}
+
+	return diffBuilder, nil
 }
 
 func padding(s mutator.Status) string {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -18,7 +18,6 @@ package report
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -310,7 +309,7 @@ func generateDiff(m mutator.Mutator) ([]string, error) {
 	original := m.OrigSnippet()
 	mutated := m.MutatedSnippet()
 	if len(original) == 0 || len(mutated) == 0 {
-		return nil, errors.New("no differences found")
+		return nil, nil
 	}
 
 	diffText, err := udiff.ToUnified("Original", "Mutated", string(original), udiff.Bytes(original, mutated), 3)
@@ -324,16 +323,16 @@ func generateDiff(m mutator.Mutator) ([]string, error) {
 	}
 
 	diffBuilder := make([]string, 0, len(lines)-3)
-	// Skip lines until the actual diff content starts
-	// --- Original
-	// +++ Mutated
-	// @@ -1 +1 @@
 	for _, line := range lines {
 		switch {
 		case line == "":
+			continue
 		case strings.HasPrefix(line, "---"):
+			continue
 		case strings.HasPrefix(line, "+++"):
+			continue
 		case strings.HasPrefix(line, "@@"):
+			continue
 		case strings.Contains(line, "No newline at end of file"):
 			continue
 		case strings.HasPrefix(line, "-"):

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -32,13 +32,12 @@ import (
 	"github.com/hectane/go-acl"
 	"github.com/spf13/viper"
 
+	"github.com/go-gremlins/gremlins/internal/configuration"
+	"github.com/go-gremlins/gremlins/internal/execution"
 	"github.com/go-gremlins/gremlins/internal/log"
 	"github.com/go-gremlins/gremlins/internal/mutator"
 	"github.com/go-gremlins/gremlins/internal/report"
 	"github.com/go-gremlins/gremlins/internal/report/internal"
-
-	"github.com/go-gremlins/gremlins/internal/configuration"
-	"github.com/go-gremlins/gremlins/internal/execution"
 )
 
 var fakePosition = newPosition("aFolder/aFile.go", 3, 12)
@@ -293,6 +292,74 @@ func TestAssessment(t *testing.T) {
 	}
 }
 
+func TestMutantNoDiff(t *testing.T) {
+	t.Run("does not print diff even when snippets are non-empty", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		log.Init(out, &bytes.Buffer{})
+		defer log.Reset()
+
+		m := stubMutant{
+			status:         mutator.Lived,
+			mutantType:     mutator.ConditionalsBoundary,
+			position:       fakePosition,
+			originSnippet:  []byte("x > y\n"),
+			mutatedSnippet: []byte("x >= y\n"),
+		}
+		report.Mutant(m)
+
+		want := "       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		got := out.String()
+		if !cmp.Equal(got, want) {
+			t.Error(cmp.Diff(want, got))
+		}
+	})
+}
+
+func TestMutantDiff(t *testing.T) {
+	t.Run("prints diff when snippets are non-empty", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		log.Init(out, &bytes.Buffer{})
+		defer log.Reset()
+
+		m := stubMutant{
+			status:         mutator.Lived,
+			mutantType:     mutator.ConditionalsBoundary,
+			position:       fakePosition,
+			originSnippet:  []byte("x > y\n"),
+			mutatedSnippet: []byte("x >= y\n"),
+		}
+		report.MutantDiff(m)
+
+		want := "       -x > y\n" +
+			"       +x >= y\n"
+		got := out.String()
+		if !cmp.Equal(got, want) {
+			t.Error(cmp.Diff(want, got))
+		}
+	})
+
+	t.Run("logs error and prints nothing when snippets are empty", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		errOut := &bytes.Buffer{}
+		log.Init(out, errOut)
+		defer log.Reset()
+
+		m := stubMutant{
+			status:     mutator.Lived,
+			mutantType: mutator.ConditionalsBoundary,
+			position:   fakePosition,
+		}
+		report.MutantDiff(m)
+
+		if out.Len() > 0 {
+			t.Errorf("expected no output, got: %q", out.String())
+		}
+		if errOut.Len() == 0 {
+			t.Error("expected error to be logged")
+		}
+	})
+}
+
 func TestMutantLog(t *testing.T) {
 	out := &bytes.Buffer{}
 	defer out.Reset()
@@ -421,15 +488,15 @@ func notWriteableDir(t *testing.T) (string, func()) {
 	t.Helper()
 	tmp := t.TempDir()
 	outPath, _ := os.MkdirTemp(tmp, "test-")
-	_ = os.Chmod(outPath, 0000)
+	_ = os.Chmod(outPath, 0o000)
 	clean := os.Chmod
 	if runtime.GOOS == "windows" {
-		_ = acl.Chmod(outPath, 0000)
+		_ = acl.Chmod(outPath, 0o000)
 		clean = acl.Chmod
 	}
 
 	return outPath, func() {
-		_ = clean(outPath, 0700)
+		_ = clean(outPath, 0o700)
 	}
 }
 
@@ -439,7 +506,6 @@ func sortOutputFile(x, y internal.OutputFile) bool {
 
 func sortMutation(x, y internal.Mutation) bool {
 	if x.Line == y.Line {
-
 		return x.Column < y.Column
 	}
 
@@ -447,9 +513,11 @@ func sortMutation(x, y internal.Mutation) bool {
 }
 
 type stubMutant struct {
-	position   token.Position
-	status     mutator.Status
-	mutantType mutator.Type
+	position       token.Position
+	status         mutator.Status
+	mutantType     mutator.Type
+	originSnippet  []byte
+	mutatedSnippet []byte
 }
 
 func (s stubMutant) Type() mutator.Type {
@@ -494,4 +562,12 @@ func (stubMutant) Apply() error {
 
 func (stubMutant) Rollback() error {
 	panic("implement me")
+}
+
+func (s stubMutant) OrigSnippet() []byte {
+	return s.originSnippet
+}
+
+func (s stubMutant) MutatedSnippet() []byte {
+	return s.mutatedSnippet
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -316,48 +316,96 @@ func TestMutantNoDiff(t *testing.T) {
 }
 
 func TestMutantDiff(t *testing.T) {
-	t.Run("prints diff when snippets are non-empty", func(t *testing.T) {
-		out := &bytes.Buffer{}
-		log.Init(out, &bytes.Buffer{})
-		defer log.Reset()
-
-		m := stubMutant{
-			status:         mutator.Lived,
-			mutantType:     mutator.ConditionalsBoundary,
-			position:       fakePosition,
-			originSnippet:  []byte("x > y\n"),
+	testCases := map[string]struct {
+		originSnippet  []byte
+		mutatedSnippet []byte
+		assertFunc     func(t *testing.T, out, errOut *bytes.Buffer)
+	}{
+		"should_log_error_when_both_snippets_are_empty": {
+			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
+				t.Helper()
+				if errOut.Len() == 0 {
+					t.Error("expected error to be logged")
+				}
+				if out.Len() > 0 {
+					t.Errorf("expected no output on error, got: %q", out.String())
+				}
+			},
+		},
+		"should_log_error_when_only_origin_snippet_is_empty": {
 			mutatedSnippet: []byte("x >= y\n"),
-		}
-		report.MutantDiff(m)
+			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
+				t.Helper()
+				if errOut.Len() == 0 {
+					t.Error("expected error to be logged")
+				}
+				if out.Len() > 0 {
+					t.Errorf("expected no output on error, got: %q", out.String())
+				}
+			},
+		},
+		"should_log_error_when_only_mutated_snippet_is_empty": {
+			originSnippet: []byte("x > y\n"),
+			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
+				t.Helper()
+				if errOut.Len() == 0 {
+					t.Error("expected error to be logged")
+				}
+				if out.Len() > 0 {
+					t.Errorf("expected no output on error, got: %q", out.String())
+				}
+			},
+		},
+		"should_print_nothing_when_snippets_are_identical": {
+			originSnippet:  []byte("x > y\n"),
+			mutatedSnippet: []byte("x > y\n"),
+			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
+				t.Helper()
+				if errOut.Len() > 0 {
+					t.Errorf("unexpected error logged: %q", errOut.String())
+				}
+				if out.Len() > 0 {
+					t.Errorf("expected no output for identical snippets, got: %q", out.String())
+				}
+			},
+		},
+		"should_print_diff_when_snippets_differ": {
+			originSnippet:  []byte("if x > y {\n  x = 10"),
+			mutatedSnippet: []byte("if x >= y {\n  x = 10"),
+			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
+				t.Helper()
+				if errOut.Len() > 0 {
+					t.Errorf("unexpected error logged: %q", errOut.String())
+				}
+				want := "       -if x > y {\n       +if x >= y {\n          x = 10\n"
+				got := out.String()
+				if !cmp.Equal(got, want) {
+					t.Error(cmp.Diff(want, got))
+				}
+			},
+		},
+	}
 
-		want := "       -x > y\n" +
-			"       +x >= y\n"
-		got := out.String()
-		if !cmp.Equal(got, want) {
-			t.Error(cmp.Diff(want, got))
-		}
-	})
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			errOut := &bytes.Buffer{}
 
-	t.Run("logs error and prints nothing when snippets are empty", func(t *testing.T) {
-		out := &bytes.Buffer{}
-		errOut := &bytes.Buffer{}
-		log.Init(out, errOut)
-		defer log.Reset()
+			log.Init(out, errOut)
+			defer log.Reset()
 
-		m := stubMutant{
-			status:     mutator.Lived,
-			mutantType: mutator.ConditionalsBoundary,
-			position:   fakePosition,
-		}
-		report.MutantDiff(m)
+			m := stubMutant{
+				status:         mutator.Lived,
+				mutantType:     mutator.ConditionalsBoundary,
+				position:       fakePosition,
+				originSnippet:  tc.originSnippet,
+				mutatedSnippet: tc.mutatedSnippet,
+			}
+			report.MutantDiff(m)
 
-		if out.Len() > 0 {
-			t.Errorf("expected no output, got: %q", out.String())
-		}
-		if errOut.Len() == 0 {
-			t.Error("expected error to be logged")
-		}
-	})
+			tc.assertFunc(t, out, errOut)
+		})
+	}
 }
 
 func TestMutantLog(t *testing.T) {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -321,38 +321,38 @@ func TestMutantDiff(t *testing.T) {
 		mutatedSnippet []byte
 		assertFunc     func(t *testing.T, out, errOut *bytes.Buffer)
 	}{
-		"should_log_error_when_both_snippets_are_empty": {
+		"should_print_nothing_when_both_snippets_are_empty": {
 			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
 				t.Helper()
-				if errOut.Len() == 0 {
-					t.Error("expected error to be logged")
+				if errOut.Len() > 0 {
+					t.Errorf("unexpected error logged: %q", errOut.String())
 				}
 				if out.Len() > 0 {
-					t.Errorf("expected no output on error, got: %q", out.String())
+					t.Errorf("expected no output for empty snippets, got: %q", out.String())
 				}
 			},
 		},
-		"should_log_error_when_only_origin_snippet_is_empty": {
+		"should_print_nothing_when_only_origin_snippet_is_empty": {
 			mutatedSnippet: []byte("x >= y\n"),
 			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
 				t.Helper()
-				if errOut.Len() == 0 {
-					t.Error("expected error to be logged")
+				if errOut.Len() > 0 {
+					t.Errorf("unexpected error logged: %q", errOut.String())
 				}
 				if out.Len() > 0 {
-					t.Errorf("expected no output on error, got: %q", out.String())
+					t.Errorf("expected no output for empty origin snippet, got: %q", out.String())
 				}
 			},
 		},
-		"should_log_error_when_only_mutated_snippet_is_empty": {
+		"should_print_nothing_when_only_mutated_snippet_is_empty": {
 			originSnippet: []byte("x > y\n"),
 			assertFunc: func(t *testing.T, out, errOut *bytes.Buffer) {
 				t.Helper()
-				if errOut.Len() == 0 {
-					t.Error("expected error to be logged")
+				if errOut.Len() > 0 {
+					t.Errorf("unexpected error logged: %q", errOut.String())
 				}
 				if out.Len() > 0 {
-					t.Errorf("expected no output on error, got: %q", out.String())
+					t.Errorf("expected no output for empty mutated snippet, got: %q", out.String())
 				}
 			},
 		},


### PR DESCRIPTION
## Proposed changes                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  Adds a new `--output-diff-statuses` flag that prints a colored unified diff for mutants whose status matches the given filter. This helps users understand exactly what code was mutated without having to manually inspect the source files.                                                                    
   
  Resolves #107.                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  When the flag is set (e.g. `--output-diff-statuses lk`), gremlins will print a colored diff (red for removed lines, green for added lines) beneath each matching mutant's status line, showing the original and mutated code with 3 lines of context.                                                            
                                                                                                                                                                                                                                                                                                                   
  ## Types of changes                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation Update (if none of the other choices apply)                                                                                                                                                                                                                                                  
   
  ## Design decisions

  - **Snippet extraction**: Rather than diffing the entire file, `extractSnippet` captures 3 lines of context around the mutation point both before (`Apply`) and after (`writeMutatedFile`) the mutation is written. This keeps diffs readable and avoids large output for big files.                             
   
  - **Diff filter is separate from output filter**: The `--output-diff-statuses` flag is intentionally independent from `--output-statuses`. This allows printing all statuses normally while only showing diffs for a subset (e.g. show all mutants but only diff lived ones with `--output-diff-statuses l`).    
                  
  - **Only `l` (Lived) and `k` (Killed) are valid diff targets**: Diffs require that a mutation was actually applied and the file was written. Statuses like `NotCovered`, `TimedOut`, `NotViable`, and `Skipped` never reach the point where `writeMutatedFile` runs, so snippets would be empty — hence they are 
  excluded from the allowed characters.
                                                                                                                                                                                                                                                                                                                   
  - **`go-udiff` library**: Used for generating the unified diff text. It is a lightweight, pure-Go implementation that doesn't shell out to `diff`. 