### PR TITLE
fix(report): treat threshold as satisfied when efficacy/coverage equals it

### DIFF
--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -390,9 +390,11 @@ gremlins unleash --test-cpu=1
 
 :material-flag: `--threshold-efficacy` · :material-sign-direction: Default: 0
 
-When set, it makes Gremlins exit with an error (code 10) if the _test efficacy_ is below the threshold. The threshold is
-satisfied when the actual efficacy is greater than or equal to the configured value (so `--threshold-efficacy 100` is
-met when every reached mutant is killed). By default it is zero, which means Gremlins never exits with an error.
+When set, it makes Gremlins exit with an error (code 10) if the _test efficacy_
+is below the threshold. The threshold is satisfied when the actual efficacy is
+greater than or equal to the configured value (so `--threshold-efficacy 100`
+is met when every reached mutant is killed). By default it is zero, which
+means Gremlins never exits with an error.
 
 The _test efficacy_ is calculated as `KILLED / (KILLED + LIVED)` and assesses how effective are the tests.
 
@@ -404,9 +406,10 @@ gremlins unleash --threshold-efficacy 80
 
 :material-flag: `--threshold-mcover` · :material-sign-direction: Default: 0
 
-When set, it makes Gremlins exit with an error (code 11) if the _mutant coverage_ is below the threshold. The threshold
-is satisfied when the actual coverage is greater than or equal to the configured value. By default it is zero, which
-means Gremlins never exits with an error.
+When set, it makes Gremlins exit with an error (code 11) if the
+_mutant coverage_ is below the threshold. The threshold is satisfied when the
+actual coverage is greater than or equal to the configured value. By default
+it is zero, which means Gremlins never exits with an error.
 
 The _mutant coverage_ is calculated as `(KILLED + LIVED) / (KILLED + LIVED + NOT_COVERED)` and assesses how many mutants
 are covered by tests.

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -390,9 +390,9 @@ gremlins unleash --test-cpu=1
 
 :material-flag: `--threshold-efficacy` · :material-sign-direction: Default: 0
 
-When set, it makes Gremlins exit with an error (code 10) if the _test efficacy_ threshold is not met. By default it is
-zero, which
-means Gremlins never exits with an error.
+When set, it makes Gremlins exit with an error (code 10) if the _test efficacy_ is below the threshold. The threshold is
+satisfied when the actual efficacy is greater than or equal to the configured value (so `--threshold-efficacy 100` is
+met when every reached mutant is killed). By default it is zero, which means Gremlins never exits with an error.
 
 The _test efficacy_ is calculated as `KILLED / (KILLED + LIVED)` and assesses how effective are the tests.
 
@@ -404,8 +404,9 @@ gremlins unleash --threshold-efficacy 80
 
 :material-flag: `--threshold-mcover` · :material-sign-direction: Default: 0
 
-When set, it makes Gremlins exit with an error (code 11) if the _mutant coverage_ threshold is not met. By default
-it is zero, which means Gremlins never exits with an error.
+When set, it makes Gremlins exit with an error (code 11) if the _mutant coverage_ is below the threshold. The threshold
+is satisfied when the actual coverage is greater than or equal to the configured value. By default it is zero, which
+means Gremlins never exits with an error.
 
 The _mutant coverage_ is calculated as `(KILLED + LIVED) / (KILLED + LIVED + NOT_COVERED)` and assesses how many mutants
 are covered by tests.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -235,14 +235,14 @@ func (r *reportStatus) assess(tEfficacy, rCoverage float64) error {
 	if et == 0 {
 		et = float64(configuration.Get[int](configuration.UnleashThresholdEfficacyKey))
 	}
-	if et > 0 && tEfficacy <= et {
+	if et > 0 && tEfficacy < et {
 		return execution.NewExitErr(execution.EfficacyThreshold)
 	}
 	ct := configuration.Get[float64](configuration.UnleashThresholdMCoverageKey)
 	if ct == 0 {
 		ct = float64(configuration.Get[int](configuration.UnleashThresholdMCoverageKey))
 	}
-	if ct > 0 && rCoverage <= ct {
+	if ct > 0 && rCoverage < ct {
 		return execution.NewExitErr(execution.MutantCoverageThreshold)
 	}
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -199,55 +199,103 @@ func TestAssessment(t *testing.T) {
 	}{
 		// Efficacy-threshold as float64
 		{
-			name:        "efficacy < efficacy-threshold",
+			name:        "efficacy < efficacy-threshold float64",
 			confKey:     configuration.UnleashThresholdEfficacyKey,
 			value:       float64(51),
 			expectError: true,
 		},
 		{
-			name:        "efficacy >= efficacy-threshold",
+			name:        "efficacy == efficacy-threshold float64",
 			confKey:     configuration.UnleashThresholdEfficacyKey,
 			value:       float64(50),
 			expectError: false,
 		},
 		{
-			name:        "efficacy-threshold == 0",
+			name:        "efficacy > efficacy-threshold float64",
+			confKey:     configuration.UnleashThresholdEfficacyKey,
+			value:       float64(49),
+			expectError: false,
+		},
+		{
+			name:        "efficacy-threshold == 0 float64",
 			confKey:     configuration.UnleashThresholdEfficacyKey,
 			value:       float64(0),
 			expectError: false,
 		},
-		// Efficacy-threshold as float64
+		// Efficacy-threshold as int
 		{
-			name:        "efficacy < efficacy-threshold",
+			name:        "efficacy < efficacy-threshold int",
 			confKey:     configuration.UnleashThresholdEfficacyKey,
 			value:       51,
 			expectError: true,
 		},
-		// Mutator coverage-threshold as float
 		{
-			name:        "coverage < coverage-threshold",
+			name:        "efficacy == efficacy-threshold int",
+			confKey:     configuration.UnleashThresholdEfficacyKey,
+			value:       50,
+			expectError: false,
+		},
+		{
+			name:        "efficacy > efficacy-threshold int",
+			confKey:     configuration.UnleashThresholdEfficacyKey,
+			value:       49,
+			expectError: false,
+		},
+		{
+			name:        "efficacy-threshold == 0 int",
+			confKey:     configuration.UnleashThresholdEfficacyKey,
+			value:       0,
+			expectError: false,
+		},
+		// Mutator coverage-threshold as float64
+		{
+			name:        "coverage < coverage-threshold float64",
 			confKey:     configuration.UnleashThresholdMCoverageKey,
 			value:       float64(51),
 			expectError: true,
 		},
 		{
-			name:        "coverage >= coverage-threshold",
+			name:        "coverage == coverage-threshold float64",
 			confKey:     configuration.UnleashThresholdMCoverageKey,
 			value:       float64(50),
 			expectError: false,
 		},
 		{
-			name:        "coverage-threshold == 0",
+			name:        "coverage > coverage-threshold float64",
+			confKey:     configuration.UnleashThresholdMCoverageKey,
+			value:       float64(49),
+			expectError: false,
+		},
+		{
+			name:        "coverage-threshold == 0 float64",
 			confKey:     configuration.UnleashThresholdMCoverageKey,
 			value:       float64(0),
 			expectError: false,
 		},
 		// Mutator coverage-threshold as int
 		{
-			name:        "coverage < coverage-threshold",
+			name:        "coverage < coverage-threshold int",
 			confKey:     configuration.UnleashThresholdMCoverageKey,
 			value:       51,
 			expectError: true,
+		},
+		{
+			name:        "coverage == coverage-threshold int",
+			confKey:     configuration.UnleashThresholdMCoverageKey,
+			value:       50,
+			expectError: false,
+		},
+		{
+			name:        "coverage > coverage-threshold int",
+			confKey:     configuration.UnleashThresholdMCoverageKey,
+			value:       49,
+			expectError: false,
+		},
+		{
+			name:        "coverage-threshold == 0 int",
+			confKey:     configuration.UnleashThresholdMCoverageKey,
+			value:       0,
+			expectError: false,
 		},
 	}
 
@@ -278,6 +326,10 @@ func TestAssessment(t *testing.T) {
 				t.Fatal("expected an error")
 			}
 			if !tc.expectError {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
 				return
 			}
 			var exitErr *execution.ExitError


### PR DESCRIPTION
## Proposed changes

The efficacy and mutant-coverage threshold checks in `internal/report/report.go`
used `<=`, which makes a configured threshold of N% unsatisfiable when the
actual value is exactly N%.

The clearest manifestation: `--threshold-efficacy 100` can never be met, even
when every reached mutant is killed — `100 <= 100` is true, so Gremlins exits
with code 10 and reports "below efficacy-threshold". The same bug existed for
`--threshold-mcover`.

The docs describe these flags as "the percent of KILLED mutants" / "how many
mutants are covered by tests", and users naturally write `100` to mean "all
reached mutants must be killed". Switching both comparisons to `<` makes the
flags behave that way: a configured threshold of N is satisfied when the actual
value is greater than or equal to N.

### Why the existing tests didn't catch this

The `!tc.expectError` branch of `TestAssessment` returned without ever
asserting `err == nil`. So the upstream test named "efficacy >= efficacy-threshold"
(value 50, actual efficacy 50%) was already returning an `ExitError` under the
old `<=` semantics — the assertion just never looked.

This PR fixes that branch (`if err != nil { t.Fatalf(...) }`) so the boundary
cases actually verify the no-error path, then adds explicit `<`, `==`, `>`, and
`== 0` cases for both efficacy and mutant-coverage, against both `float64` and
`int` configuration values (the assess code reads both via the
`Get[float64]` → `Get[int]` fallback).

### Changes

- `internal/report/report.go`: `<=` → `<` for both efficacy and mutant-coverage
  threshold checks.
- `internal/report/report_test.go`: assert `err == nil` on the no-error branch;
  add `==` / `>` / `== 0` boundary cases for `float64` and `int` config values
  on both thresholds; rename rows so duplicate names get distinct identifiers.
- `docs/docs/usage/commands/unleash/index.md`: clarify that the threshold is
  satisfied when actual ≥ configured (e.g. `--threshold-efficacy 100` is met
  when every reached mutant is killed).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is technically a behavior change for anyone who today relies on
`--threshold-efficacy N` failing at exactly N%, but I'd argue that behavior
isn't what the flag's name or documentation imply, and the `100` case is
clearly a bug (the flag is unreachable). Happy to gate this behind a different
flag name or a deprecation cycle if maintainers prefer — let me know.
