### PR TITLE
fix(configuration): coerce typed flag values via spf13/cast

### DIFF
--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -21,7 +21,64 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/go-gremlins/gremlins/internal/configuration"
 )
+
+type cliCase struct {
+	want      any
+	getResult func(string) any
+	flag      Flag
+	args      []string
+}
+
+func TestSetBindsTypedValueFromCLI(t *testing.T) {
+	testCases := []cliCase{
+		{
+			flag: Flag{
+				Name:     "threshold-efficacy",
+				CfgKey:   "unleash.threshold.efficacy",
+				DefaultV: float64(0),
+				Usage:    "test usage",
+			},
+			args:      []string{"--threshold-efficacy", "50"},
+			getResult: func(k string) any { return configuration.Get[float64](k) },
+			want:      float64(50),
+		},
+		{
+			flag: Flag{
+				Name:     "workers",
+				CfgKey:   "unleash.workers",
+				DefaultV: 0,
+				Usage:    "test usage",
+			},
+			args:      []string{"--workers", "4"},
+			getResult: func(k string) any { return configuration.Get[int](k) },
+			want:      4,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.flag.Name, func(t *testing.T) {
+			defer viper.Reset()
+
+			cmd := &cobra.Command{Use: "test", Run: func(_ *cobra.Command, _ []string) {}}
+			// #nosec G601 - We are in tests, we don't care
+			if err := Set(cmd, &tc.flag); err != nil {
+				t.Fatal("Set should not fail")
+			}
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal("Execute should not fail")
+			}
+
+			if got := tc.getResult(tc.flag.CfgKey); got != tc.want {
+				t.Errorf("expected configuration.Get(%q) to be %T(%v), got %T(%v)", tc.flag.CfgKey, tc.want, tc.want, got, got)
+			}
+		})
+	}
+}
 
 type unsupportedType int
 

--- a/cmd/unleash_test.go
+++ b/cmd/unleash_test.go
@@ -22,6 +22,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/go-gremlins/gremlins/internal/configuration"
 	"github.com/go-gremlins/gremlins/internal/mutator"
 )
@@ -200,4 +203,49 @@ func TestUnleash(t *testing.T) {
 			t.Errorf("expected %q have default %q, got %q", s, wantDef, mtf.DefValue)
 		}
 	}
+}
+
+func TestUnleashFlagsPropagateToConfiguration(t *testing.T) {
+	c, err := newUnleashCmd(context.Background())
+	if err != nil {
+		t.Fatal("newUnleashCmd should not fail")
+	}
+	c.cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+	c.cmd.SetArgs([]string{"--threshold-efficacy", "50", "--threshold-mcover", "25", "--workers", "4"})
+	if err := c.cmd.Execute(); err != nil {
+		t.Fatal("Execute should not fail")
+	}
+
+	testCases := []struct {
+		got  any
+		want any
+		key  string
+	}{
+		{
+			key:  configuration.UnleashThresholdEfficacyKey,
+			got:  configuration.Get[float64](configuration.UnleashThresholdEfficacyKey),
+			want: float64(50),
+		},
+		{
+			key:  configuration.UnleashThresholdMCoverageKey,
+			got:  configuration.Get[float64](configuration.UnleashThresholdMCoverageKey),
+			want: float64(25),
+		},
+		{
+			key:  configuration.UnleashWorkersKey,
+			got:  configuration.Get[int](configuration.UnleashWorkersKey),
+			want: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.key, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("expected %q to be %v, got %v", tc.key, tc.want, tc.got)
+			}
+		})
+	}
+
+	viper.Reset()
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b
 	github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -26,7 +27,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
-	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 
 	"github.com/go-gremlins/gremlins/internal/mutator"
@@ -180,11 +181,37 @@ func Set[T any](k string, v T) {
 }
 
 // Get offers synchronised access to Viper.
+//
+// Values bound from pflag may surface through viper.Get as their string
+// representation rather than the native Go type, so a plain type assertion
+// would silently yield the zero value. Coerce via spf13/cast for the
+// numeric and string types Gremlins uses, falling back to the assertion
+// for anything else (slices, custom types).
 func Get[T any](k string) T {
-	var r T
 	mutex.RLock()
 	defer mutex.RUnlock()
-	r, _ = viper.Get(k).(T)
+
+	v := viper.Get(k)
+	var zero T
+	if v == nil {
+		return zero
+	}
+
+	var coerced any
+	switch any(zero).(type) {
+	case float64:
+		coerced = cast.ToFloat64(v)
+	case int:
+		coerced = cast.ToInt(v)
+	case bool:
+		coerced = cast.ToBool(v)
+	case string:
+		coerced = cast.ToString(v)
+	default:
+		coerced = v
+	}
+
+	r, _ := coerced.(T)
 
 	return r
 }

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -205,12 +205,9 @@ func TestConfigPaths(t *testing.T) {
 			filepath.Join(home, ".gremlins"),
 		)
 
-		// Then module root
+		// Then module root, then current folder
 		moduleRoot, _ := os.Getwd()
-		want = append(want, moduleRoot)
-
-		// Last current folder
-		want = append(want, ".")
+		want = append(want, moduleRoot, ".")
 
 		got := defaultConfigPaths()
 
@@ -233,14 +230,12 @@ func TestConfigPaths(t *testing.T) {
 			want = append(want, "/etc/gremlins")
 		}
 
-		// Then $XDG_CONFIG_HOME and $HOME
+		// Then $XDG_CONFIG_HOME and $HOME, then current folder
 		want = append(want,
 			filepath.Join(home, ".config", "gremlins", "gremlins"),
 			filepath.Join(home, ".gremlins"),
+			".",
 		)
-
-		// Last current folder
-		want = append(want, ".")
 
 		got := defaultConfigPaths()
 
@@ -271,12 +266,9 @@ func TestConfigPaths(t *testing.T) {
 			filepath.Join(customPath, "gremlins", "gremlins"),
 			filepath.Join(home, ".gremlins"))
 
-		// Then Go module root
+		// Then Go module root, then current directory
 		moduleRoot, _ := os.Getwd()
-		want = append(want, moduleRoot)
-
-		// Last the current directory
-		want = append(want, ".")
+		want = append(want, moduleRoot, ".")
 
 		got := defaultConfigPaths()
 

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -24,10 +24,66 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/go-gremlins/gremlins/internal/mutator"
 )
+
+func TestGetFromBoundPFlag(t *testing.T) {
+	testCases := []struct {
+		register func(fs *pflag.FlagSet, name string)
+		check    func(t *testing.T, cfgKey string)
+		name     string
+		flagName string
+		cfgKey   string
+		args     []string
+	}{
+		{
+			name:     "float64",
+			flagName: "efficacy",
+			cfgKey:   "unleash.threshold.efficacy",
+			args:     []string{"--efficacy", "50"},
+			register: func(fs *pflag.FlagSet, name string) { fs.Float64(name, 0, "") },
+			check: func(t *testing.T, cfgKey string) {
+				t.Helper()
+				if got := Get[float64](cfgKey); got != 50.0 {
+					t.Errorf("Get[float64](%q) = %v, want 50.0", cfgKey, got)
+				}
+			},
+		},
+		{
+			name:     "int",
+			flagName: "workers",
+			cfgKey:   "unleash.workers",
+			args:     []string{"--workers", "4"},
+			register: func(fs *pflag.FlagSet, name string) { fs.Int(name, 0, "") },
+			check: func(t *testing.T, cfgKey string) {
+				t.Helper()
+				if got := Get[int](cfgKey); got != 4 {
+					t.Errorf("Get[int](%q) = %v, want 4", cfgKey, got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			tc.register(fs, tc.flagName)
+			if err := viper.BindPFlag(tc.cfgKey, fs.Lookup(tc.flagName)); err != nil {
+				t.Fatal("BindPFlag should not fail")
+			}
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatal("Parse should not fail")
+			}
+
+			tc.check(t, tc.cfgKey)
+			viper.Reset()
+		})
+	}
+}
 
 type envEntry struct {
 	name  string


### PR DESCRIPTION
## Proposed changes

Closes #216.

`--threshold-efficacy` and `--threshold-mcover` never produced a non-zero exit code, even when the actual efficacy/coverage was below the threshold. The same thresholds set via `.gremlins.yaml` worked correctly, so the bug only affected the CLI-flag path.

### Root cause

`configuration.Get[T]` used an unchecked type assertion against `viper.Get`:

```go
r, _ = viper.Get(k).(T)
```

When a value is bound into Viper through `viper.BindPFlag`, pflag-resolved `float64` values surface as their string representation (via `pflag.Value.String()`), so the assertion to `float64` silently failed and returned the zero value. The threshold check in `internal/report/report.go` then saw `et == 0` and skipped enforcement.

Config-file values bypassed this because Viper stores YAML scalars as native Go types, so the assertion succeeded.

### Fix

Coerce `float64`, `int`, `bool`, and `string` through `spf13/cast` (already an indirect dependency), and fall back to the assertion for slices and other types. This normalizes both pflag-sourced and config-sourced values to the native Go type before they leave `Get[T]`.

### Tests

Added three layered regression tests so the bug stays fixed regardless of where a future refactor lands:

- `internal/configuration`: `TestGetFromBoundPFlag` — `Get[T]` over a bound pflag in isolation.
- `cmd/internal/flags`: `TestSetBindsTypedValueFromCLI` — full `flags.Set` → cobra parse → `configuration.Get[T]`.
- `cmd`: `TestUnleashFlagsPropagateToConfiguration` — exercises the real `unleash` command surface.

All three fail without the fix and pass with it.

End-to-end verified by rebuilding the binary and running `gremlins unleash --threshold-efficacy 50` against a small module with 0% efficacy: exit code is now `10` (was `0`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

`spf13/cast` is promoted from indirect to direct in `go.mod`; it was already pulled in transitively through `viper`, so no new dependency is added to the module graph.

The original feature request in #216 also asked for `--fail-lived` / `--fail-not-covered` flags. That part is intentionally **out of scope** for this PR — this change only fixes the existing threshold flags so they actually work as documented. Per-status fail flags can be a follow-up.
