### PR TITLE
fix(signal): mark in-flight mutants on shutdown, not LIVED

### DIFF
--- a/cmd/gremlins/main.go
+++ b/cmd/gremlins/main.go
@@ -54,13 +54,26 @@ func main() {
 }
 
 func ctxDoneOnSignal() context.Context {
-	done := make(chan os.Signal, 1)
+	// Buffer of 2 lets a follow-up signal be queued (e.g. CI runner sending
+	// SIGTERM then SIGKILL is masked, but Ctrl-C twice from a TTY isn't).
+	// We never close `done`: closing while `os/signal` may still write to it
+	// causes "panic: send on closed channel" from signal.process. Instead,
+	// we call signal.Stop to detach the runtime sender before we drop our
+	// reference to the channel.
+	done := make(chan os.Signal, 2)
 	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-done
 		cancel()
-		close(done)
+		// A second signal forces immediate exit. The first one triggered
+		// the graceful-shutdown path via the cancelled ctx; if the user
+		// hits Ctrl-C again they want out _now_.
+		go func() {
+			<-done
+			signal.Stop(done)
+			os.Exit(130) // 128 + SIGINT
+		}()
 	}()
 
 	return ctx

--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -60,6 +60,7 @@ const (
 	paramWorkers            = "workers"
 	paramTimeoutCoefficient = "timeout-coefficient"
 	paramTimeoutMax         = "timeout-max"
+	paramCompileAllowance   = "compile-allowance"
 	paramOnShutdownStatus   = "on-shutdown-status"
 
 	// Thresholds.
@@ -223,6 +224,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 		{Name: paramTestCPU, CfgKey: configuration.UnleashTestCPUKey, DefaultV: 0, Usage: "the number of CPUs to allow each test run to use"},
 		{Name: paramTimeoutCoefficient, CfgKey: configuration.UnleashTimeoutCoefficientKey, DefaultV: 0, Usage: "the coefficient by which the timeout is increased"},
 		{Name: paramTimeoutMax, CfgKey: configuration.UnleashTimeoutMaxKey, DefaultV: "", Usage: "absolute ceiling on a single mutant's test run, as a Go duration (e.g. '15s'); caps the coefficient-derived timeout so a non-terminating mutant cannot exhaust the machine. Empty means no ceiling"},
+		{Name: paramCompileAllowance, CfgKey: configuration.UnleashCompileAllowanceKey, DefaultV: "", Usage: "time a mutant is allowed to COMPILE, as a Go duration (e.g. '2m'), on top of the bound on its test run; the two together form the deadline that also bounds a compile that has hung. Empty uses the default"},
 		{Name: paramOnShutdownStatus, CfgKey: configuration.UnleashOnShutdownStatusKey, DefaultV: "not-run", Usage: "status to record for in-flight mutants when the run is cancelled (e.g. SIGTERM from a CI runner); one of 'not-run', 'timed-out', 'lived'"},
 	}
 

--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -59,6 +59,7 @@ const (
 	paramTestCPU            = "test-cpu"
 	paramWorkers            = "workers"
 	paramTimeoutCoefficient = "timeout-coefficient"
+	paramOnShutdownStatus   = "on-shutdown-status"
 
 	// Thresholds.
 	paramThresholdEfficacy  = "threshold-efficacy"
@@ -220,6 +221,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 		{Name: paramWorkers, CfgKey: configuration.UnleashWorkersKey, DefaultV: 0, Usage: "the number of workers to use in mutation testing"},
 		{Name: paramTestCPU, CfgKey: configuration.UnleashTestCPUKey, DefaultV: 0, Usage: "the number of CPUs to allow each test run to use"},
 		{Name: paramTimeoutCoefficient, CfgKey: configuration.UnleashTimeoutCoefficientKey, DefaultV: 0, Usage: "the coefficient by which the timeout is increased"},
+		{Name: paramOnShutdownStatus, CfgKey: configuration.UnleashOnShutdownStatusKey, DefaultV: "not-run", Usage: "status to record for in-flight mutants when the run is cancelled (e.g. SIGTERM from a CI runner); one of 'not-run', 'timed-out', 'lived'"},
 	}
 
 	for _, f := range fls {

--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -59,6 +59,7 @@ const (
 	paramTestCPU            = "test-cpu"
 	paramWorkers            = "workers"
 	paramTimeoutCoefficient = "timeout-coefficient"
+	paramTimeoutMax         = "timeout-max"
 	paramOnShutdownStatus   = "on-shutdown-status"
 
 	// Thresholds.
@@ -221,6 +222,7 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 		{Name: paramWorkers, CfgKey: configuration.UnleashWorkersKey, DefaultV: 0, Usage: "the number of workers to use in mutation testing"},
 		{Name: paramTestCPU, CfgKey: configuration.UnleashTestCPUKey, DefaultV: 0, Usage: "the number of CPUs to allow each test run to use"},
 		{Name: paramTimeoutCoefficient, CfgKey: configuration.UnleashTimeoutCoefficientKey, DefaultV: 0, Usage: "the coefficient by which the timeout is increased"},
+		{Name: paramTimeoutMax, CfgKey: configuration.UnleashTimeoutMaxKey, DefaultV: "", Usage: "absolute ceiling on a single mutant's test run, as a Go duration (e.g. '15s'); caps the coefficient-derived timeout so a non-terminating mutant cannot exhaust the machine. Empty means no ceiling"},
 		{Name: paramOnShutdownStatus, CfgKey: configuration.UnleashOnShutdownStatusKey, DefaultV: "not-run", Usage: "status to record for in-flight mutants when the run is cancelled (e.g. SIGTERM from a CI runner); one of 'not-run', 'timed-out', 'lived'"},
 	}
 

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -456,6 +456,26 @@ gremlins unleash --timeout-coefficient=10
     indicate an issue.
 [//]: # (@formatter:on)
 
+### On-shutdown status
+
+:material-flag: `--on-shutdown-status` · :material-sign-direction: Default: `not-run`
+
+Controls the `Status` recorded for mutants that were still in-flight when the run was cancelled
+(e.g. `SIGTERM` from a CI runner that hit its job timeout, or Ctrl-C from the terminal).
+
+Allowed values:
+
+- `not-run` (default) — record cancelled-in-flight mutants as `NOT COVERED`. Truthful: they were
+  never observed.
+- `timed-out` — record them as `TIMED OUT`. Useful if you want test-efficacy
+  (`KILLED / (KILLED + LIVED)`) to ignore them.
+- `lived` — legacy behaviour: record them as `LIVED`. Available for backwards compatibility,
+  but misleading — these mutants were not tested, so they should not be counted as survivors.
+
+```shell
+gremlins unleash --on-shutdown-status=timed-out
+```
+
 ### Workers
 
 :material-flag: `--workers` · :material-sign-direction: Default: `0`

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -497,14 +497,14 @@ gremlins unleash --timeout-max=5s --compile-allowance=3m
 A malformed or non-positive value is reported on stderr and ignored, leaving
 the default allowance in place.
 
-!!! note "A timeout is read from the output, not the exit status"
+!!! note "Verdicts are read from the output, not the exit status"
     `go test` reports a failing test, a package that does not build and a test
     that ran past its `-timeout` all as exit status 1 — only the test *binary*
-    exits 2, and what Gremlins spawns is `go`. Taking that 1 at face value would
-    record a timed-out mutant as `KILLED`, crediting a detection that never
-    happened, so Gremlins scans the child's output for the timeout panic and
-    records `TIMED OUT` instead. The output is scanned as it streams and then
-    discarded, so a mutant that prints without bound cannot exhaust memory.
+    exits 2, and what Gremlins spawns is `go`. Gremlins therefore scans the
+    child's output to tell the three apart, so a timed-out mutant is recorded
+    `TIMED OUT` rather than credited as a detection, and a mutant that does not
+    compile is recorded `NOT VIABLE`. The output is scanned as it streams and
+    then discarded, so a mutant that prints without bound cannot exhaust memory.
 
 [//]: # (@formatter:off)
 !!! note "Result Consistency"

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -440,6 +440,34 @@ coefficient. For example:
 gremlins unleash --timeout-coefficient=10
 ```
 
+### Timeout max
+
+:material-flag: `--timeout-max` · :material-sign-direction:
+Default: `""` (no ceiling)
+
+An absolute ceiling on a single mutant's test run, as a Go duration. It caps
+the coefficient-derived timeout; it never raises it.
+
+The coefficient scales the timeout by how long the package's own tests take,
+which is unrelated to how much damage a mutant can do in that time. A mutant
+that inverts a loop-advance statement (`i++` → `i--`) inside a scanning loop
+that appends on every iteration never terminates and allocates until the
+machine runs out of memory. On a CI runner the OOM killer then reaps the
+runner agent itself and the job dies with no verdict at all. Because the
+coefficient hands the longest timeouts to the slowest-testing packages, those
+packages are the most exposed — which is backwards.
+
+This flag bounds that exposure independently of the baseline. Past the
+ceiling the mutant is killed and recorded as `TIMED OUT`, the honest verdict
+for a mutant that did not terminate.
+
+```shell
+gremlins unleash --timeout-max=15s
+```
+
+A malformed or non-positive value is reported on stderr and ignored, leaving
+the run with no ceiling.
+
 [//]: # (@formatter:off)
 !!! note "Result Consistency"
     You may observe small fluctuations in the number of

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -497,14 +497,14 @@ gremlins unleash --timeout-max=5s --compile-allowance=3m
 A malformed or non-positive value is reported on stderr and ignored, leaving
 the default allowance in place.
 
-!!! note "Verdicts are read from the output, not the exit status"
+!!! note "A timeout is read from the output, not the exit status"
     `go test` reports a failing test, a package that does not build and a test
     that ran past its `-timeout` all as exit status 1 — only the test *binary*
-    exits 2, and what Gremlins spawns is `go`. Gremlins therefore scans the
-    child's output to tell the three apart, so a timed-out mutant is recorded
-    `TIMED OUT` rather than credited as a detection, and a mutant that does not
-    compile is recorded `NOT VIABLE`. The output is scanned as it streams and
-    then discarded, so a mutant that prints without bound cannot exhaust memory.
+    exits 2, and what Gremlins spawns is `go`. Taking that 1 at face value would
+    record a timed-out mutant as `KILLED`, crediting a detection that never
+    happened, so Gremlins scans the child's output for the timeout panic and
+    records `TIMED OUT` instead. The output is scanned as it streams and then
+    discarded, so a mutant that prints without bound cannot exhaust memory.
 
 [//]: # (@formatter:off)
 !!! note "Result Consistency"

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -445,8 +445,9 @@ gremlins unleash --timeout-coefficient=10
 :material-flag: `--timeout-max` · :material-sign-direction:
 Default: `""` (no ceiling)
 
-An absolute ceiling on a single mutant's test run, as a Go duration. It caps
-the coefficient-derived timeout; it never raises it.
+An absolute ceiling on a single mutant's test RUN, as a Go duration. It caps
+the coefficient-derived timeout; it never raises it. It bounds only the run:
+compiling the mutated package is charged to `--compile-allowance` instead.
 
 The coefficient scales the timeout by how long the package's own tests take,
 which is unrelated to how much damage a mutant can do in that time. A mutant
@@ -467,6 +468,43 @@ gremlins unleash --timeout-max=15s
 
 A malformed or non-positive value is reported on stderr and ignored, leaving
 the run with no ceiling.
+
+### Compile allowance
+
+:material-flag: `--compile-allowance` · :material-sign-direction:
+Default: `2m`
+
+How long a mutant is allowed to COMPILE, as a Go duration, on top of the bound
+on its test run.
+
+Compile time and run time scale with unrelated things: compile time with the
+size of the package and its dependency graph, run time with the test that
+adjudicates the mutant. Charging both to one number makes the slow-compiling
+packages the ones whose mutants time out — including mutants whose tests would
+have reached a verdict in milliseconds. So the two are bounded separately:
+`go test -timeout` gets the run bound, and a deadline of `run bound + compile
+allowance` covers compilation and the run together.
+
+That deadline is a backstop, not a second leash. No `-timeout` can bound a
+compile that has hung, because there is no test binary yet to enforce one, so
+something has to. A mutant killed by either bound is recorded `TIMED OUT`,
+which stays in the efficacy denominator and credits no test with a detection.
+
+```shell
+gremlins unleash --timeout-max=5s --compile-allowance=3m
+```
+
+A malformed or non-positive value is reported on stderr and ignored, leaving
+the default allowance in place.
+
+!!! note "Verdicts are read from the output, not the exit status"
+    `go test` reports a failing test, a package that does not build and a test
+    that ran past its `-timeout` all as exit status 1 — only the test *binary*
+    exits 2, and what Gremlins spawns is `go`. Gremlins therefore scans the
+    child's output to tell the three apart, so a timed-out mutant is recorded
+    `TIMED OUT` rather than credited as a detection, and a mutant that does not
+    compile is recorded `NOT VIABLE`. The output is scanned as it streams and
+    then discarded, so a mutant that prints without bound cannot exhaust memory.
 
 [//]: # (@formatter:off)
 !!! note "Result Consistency"

--- a/docs/docs/usage/mutations/arithmetic_base.md
+++ b/docs/docs/usage/mutations/arithmetic_base.md
@@ -29,3 +29,11 @@ _Arithmetic base_ will perform inversions on basic arithmetic operations.
     ```go
     a := 1 - 2
     ```
+
+[//]: # (@formatter:off)
+!!! note "Only where the operands allow it"
+    Go's `+` is also string concatenation, and no other arithmetic operator is defined on strings.
+    Gremlins type-checks a candidate mutant before emitting it, so `a + "-" + b` yields no
+    `ADD -> SUB` mutant, and a `MUL -> QUO` that turns a constant into zero yields none either when
+    something divides by that constant. See [about mutations](index.md#mutants-gremlins-does-not-generate).
+[//]: # (@formatter:on)

--- a/docs/docs/usage/mutations/index.md
+++ b/docs/docs/usage/mutations/index.md
@@ -25,3 +25,45 @@ Each _mutant type_ can be enabled or disabled, and only a subset of mutations is
 | [INVERT BITWISE ](invert_bitwise.md)                   |  FALSE  |
 | [INVERT BWASSIGN ](invert_bitwise_assignments.md)      |  FALSE  |
 | [REMOVE_SELF_ASSIGNMENTS ](remove_self_assignments.md) |  FALSE  |
+
+## Mutants Gremlins does not generate
+
+A mutant the Go compiler rejects is not a fault a test suite failed to catch. It cannot be
+detected, so no verdict describes the suite: recording it as killed pays the suite for the
+compiler's work, and recording it as not viable leaves the package's mutant set padded with
+entries that describe the compiler. So Gremlins does not generate one.
+
+The mutation tables in this section say which rewrites are _meaningful_ for a token read on its
+own, which is all a table can say. Whether the result is a program depends on things the token
+does not carry:
+
+- **The operand types.** Go defines `+` on strings and defines nothing else on them, so
+  [arithmetic base](arithmetic_base.md) and [invert assignments](invert_assignments.md) both map a
+  token whose operands forbid the mutation.
+- **The constant values around it.** `7 * 24 * time.Hour` rewritten to `7 / 24 * time.Hour` is a
+  legal constant expression; it is the `d / week` further down the file that becomes a division by
+  zero.
+- **The statements the enclosing function admits.** [invert loop ctrl](invert_loop.md) turns a
+  `break` inside a `switch` into a `continue` that is not in a loop, and turns the `continue` that
+  keeps a `for` from terminating into a `break` that leaves the function missing a return.
+- **The position the token was read in.** `&x` is address-of, not bitwise AND — see
+  [invert bitwise](invert_bitwise.md).
+
+Gremlins answers the first three by type-checking the candidate mutant's whole package before
+emitting it, which is the only oracle precise enough and the only unit wide enough to see an error
+that surfaces away from the mutation. A package that cannot be loaded and type-checked as it stands
+is not used as an oracle at all: its mutants are generated and left to the compiler, exactly as
+before, and a line naming the package says so. Dropping a mutant nobody proved illegal would shrink
+the set a mutation score is measured against, which is worse than the padding it removes.
+
+[//]: # (@formatter:off)
+!!! note "`go vet` is not the compiler"
+    `go test` runs a subset of `go vet` before it builds anything and reports a finding as
+    `FAIL pkg [build failed]` — from the outside, indistinguishable from source that does not
+    compile. One of those analyzers, `bools`, rejects exactly what
+    [invert logical](invert_logical.md) produces from `name == a || name == b`: a conjunction of
+    equalities against distinct constants, which it calls "suspect and". Those mutants are legal Go
+    and a real change of behaviour, so Gremlins keeps generating them and runs the mutated tests
+    with `-vet=off` instead. A style analyzer does not get to decide whether a mutant may be
+    adjudicated.
+[//]: # (@formatter:on)

--- a/docs/docs/usage/mutations/invert_assignments.md
+++ b/docs/docs/usage/mutations/invert_assignments.md
@@ -32,3 +32,11 @@ and right operands to the left operand.
     a := 1
     a /= 2
     ```
+
+[//]: # (@formatter:off)
+!!! note "Only where the operands allow it"
+    `s += suffix` on a string has no `-=` counterpart: Go defines `+` on strings and nothing else.
+    Gremlins type-checks a candidate mutant before emitting it, so that mutation is not generated.
+    `REMOVE_SELF_ASSIGNMENTS` still applies at the same site. See
+    [about mutations](index.md#mutants-gremlins-does-not-generate).
+[//]: # (@formatter:on)

--- a/docs/docs/usage/mutations/invert_bitwise.md
+++ b/docs/docs/usage/mutations/invert_bitwise.md
@@ -30,3 +30,17 @@ _Invert bitwise_ will perform inversions on basic bit operations.
     ```go
     a := 1 | 2
     ```
+
+[//]: # (@formatter:off)
+!!! note "Only the infix operators"
+    Go spells `&` and `^` the same in prefix position, where they mean
+    address-of and bitwise complement rather than AND and XOR. Applying the
+    table above to those would produce source no compiler accepts — `&Foo{}`
+    becomes `|Foo{}`, which does not parse, and `^u` becomes `&u`, which no
+    longer has the operand's type. A mutant a compiler rejects is not a fault
+    the tests failed to catch, so Gremlins does not generate one: `&x` and `^x`
+    are left alone, while `-x` and `+x`, whose prefix meaning is the same
+    arithmetic as their infix one, are still mutated by
+    [arithmetic base](arithmetic_base.md) and
+    [invert negatives](invert_negatives.md).
+[//]: # (@formatter:on)

--- a/docs/docs/usage/mutations/invert_logical.md
+++ b/docs/docs/usage/mutations/invert_logical.md
@@ -31,3 +31,11 @@ _Invert logical operators_ will perform inversions on logical operators.
     ```go
     a := true || false
     ```
+
+[//]: # (@formatter:off)
+!!! note "These mutants trip `go vet`, and are generated anyway"
+    `name == a || name == b` inverted to `&&` is what `go vet`'s `bools` analyzer calls
+    "suspect and", and `go test` turns that into `FAIL pkg [build failed]` before any test runs.
+    The mutant is legal Go and a real change of behaviour, so Gremlins generates it and runs the
+    mutated tests with `-vet=off`. See [about mutations](index.md#mutants-gremlins-does-not-generate).
+[//]: # (@formatter:on)

--- a/docs/docs/usage/mutations/invert_loop.md
+++ b/docs/docs/usage/mutations/invert_loop.md
@@ -34,3 +34,12 @@ _Invert loop control_ will perform inversions on control operations, which means
         break
     }
     ```
+
+[//]: # (@formatter:off)
+!!! note "Only where the statement is legal"
+    `break` and `continue` are not interchangeable everywhere they both parse. A `break` inside a
+    `switch` that no loop encloses becomes a `continue` that is not in a loop; a `continue` that is
+    what keeps a `for {}` from terminating becomes a `break` that leaves the enclosing function
+    missing a return. Gremlins type-checks a candidate mutant before emitting it, so neither is
+    generated. See [about mutations](index.md#mutants-gremlins-does-not-generate).
+[//]: # (@formatter:on)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,10 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -48,6 +48,7 @@ const (
 	UnleashThresholdEfficacyKey  = "unleash.threshold.efficacy"
 	UnleashThresholdMCoverageKey = "unleash.threshold.mutant-coverage"
 	UnleashOutputDiffStatusesKey = "unleash.output-diff-statuses"
+	UnleashOnShutdownStatusKey   = "unleash.on-shutdown-status"
 )
 
 const (

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -42,6 +42,7 @@ const (
 	UnleashWorkersKey            = "unleash.workers"
 	UnleashTestCPUKey            = "unleash.test-cpu"
 	UnleashTimeoutCoefficientKey = "unleash.timeout-coefficient"
+	UnleashTimeoutMaxKey         = "unleash.timeout-max"
 	UnleashIntegrationMode       = "unleash.integration"
 	UnleashExcludeFiles          = "unleash.exclude-files"
 	UnleashDiffRef               = "unleash.diff"

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -43,6 +43,7 @@ const (
 	UnleashTestCPUKey            = "unleash.test-cpu"
 	UnleashTimeoutCoefficientKey = "unleash.timeout-coefficient"
 	UnleashTimeoutMaxKey         = "unleash.timeout-max"
+	UnleashCompileAllowanceKey   = "unleash.compile-allowance"
 	UnleashIntegrationMode       = "unleash.integration"
 	UnleashExcludeFiles          = "unleash.exclude-files"
 	UnleashDiffRef               = "unleash.diff"

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -145,7 +145,7 @@ func (mu *Engine) runOnFile(fileName string) {
 }
 
 func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.File, node *NodeToken) {
-	mutantTypes, ok := TokenMutantType[node.Tok()]
+	mutantTypes, ok := MutantTypesFor(node)
 	if !ok {
 		return
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -98,6 +98,13 @@ func WithDirFs(dirFS fs.FS) Option {
 // It walks the fs.FS provided and checks every .go file which is not a test.
 // For each file it will scan for tokenMutations and gather all the mutants found.
 func (mu *Engine) Run(ctx context.Context) report.Results {
+	// If the dealer is the standard MutantExecutorDealer, hand it the run
+	// context so that in-flight mutants can be marked correctly when the
+	// runner cancels (e.g. SIGTERM at job timeout) instead of falling
+	// through to the default Lived branch.
+	if d, ok := mu.jDealer.(*MutantExecutorDealer); ok {
+		d.SetRunCtx(ctx)
+	}
 	mu.mutantStream = make(chan mutator.Mutator)
 	go func() {
 		defer close(mu.mutantStream)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -52,6 +52,7 @@ type Engine struct {
 	mutantStream chan mutator.Mutator
 	module       gomodule.GoModule
 	logger       report.MutantLogger
+	viability    Viability
 }
 
 // CodeData is used to check if the mutant should be executed.
@@ -69,13 +70,17 @@ type Option func(m Engine) Engine
 // It gets a fs.FS on which to perform the analysis, a CodeData to
 // check if the mutants are executable and a sets of Option.
 func New(mod gomodule.GoModule, codeData CodeData, jDealer ExecutorDealer, opts ...Option) Engine {
-	dirFS := os.DirFS(filepath.Join(mod.Root, mod.CallingDir))
+	dir := filepath.Join(mod.Root, mod.CallingDir)
 	mut := Engine{
 		module:   mod,
 		jDealer:  jDealer,
 		codeData: codeData,
-		fs:       dirFS,
+		fs:       os.DirFS(dir),
 		logger:   report.NewLogger(),
+		viability: NewTypeViability(
+			dir,
+			configuration.Get[string](configuration.UnleashTagsKey),
+		),
 	}
 	for _, opt := range opts {
 		mut = opt(mut)
@@ -88,6 +93,18 @@ func New(mod gomodule.GoModule, codeData CodeData, jDealer ExecutorDealer, opts 
 func WithDirFs(dirFS fs.FS) Option {
 	return func(m Engine) Engine {
 		m.fs = dirFS
+
+		return m
+	}
+}
+
+// WithViability overrides the Viability the Engine consults before emitting a
+// mutant. A nil Viability emits every mutant the token table maps, which is
+// what gremlins did before one existed; the gate in unary_mutation_test.go
+// uses it to show what the default checker is holding back.
+func WithViability(v Viability) Option {
+	return func(m Engine) Engine {
+		m.viability = v
 
 		return m
 	}
@@ -151,8 +168,12 @@ func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.F
 	}
 
 	pkg := mu.pkgName(fileName, file.Name.Name)
+	position := set.Position(node.TokPos)
 	for _, mt := range mutantTypes {
 		if !configuration.Get[bool](configuration.MutantTypeEnabledKey(mt)) {
+			continue
+		}
+		if !mu.viable(position, node.Tok(), mt) {
 			continue
 		}
 		mutantType := mt
@@ -162,6 +183,21 @@ func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.F
 
 		mu.mutantStream <- tm
 	}
+}
+
+// viable reports whether applying mt to tok at position yields legal Go. The
+// token table maps a token to the mutations that are MEANINGFUL for it; only
+// the source around it decides whether they are legal. See Viability.
+func (mu *Engine) viable(position token.Position, tok token.Token, mt mutator.Type) bool {
+	if mu.viability == nil {
+		return true
+	}
+	mutated, ok := tokenMutations[mt][tok]
+	if !ok {
+		return true
+	}
+
+	return mu.viability.Viable(position, mutated)
 }
 
 func (mu *Engine) pkgName(fileName, fPkg string) string {

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -488,10 +488,31 @@ func shutdownStatus() mutator.Status {
 	return mutator.NotCovered
 }
 
+// vetOff disables the `go vet` subset that `go test` runs before it builds
+// anything.
+//
+// That subset is not the compiler, and the difference matters here. Its `bools`
+// analyzer reports a conjunction of equalities against distinct operands —
+// `name == a && name == b` — as "suspect and", and `go test` turns that into
+// `FAIL pkg [build failed]` even though `go build` accepts the file without a
+// word. That shape is precisely what INVERT_LOGICAL produces from the very
+// common `name == a || name == b`, so with vet on, a whole class of mutants
+// could never reach a test binary.
+//
+// Every one of them is legal Go and a real change of behaviour: the mutated
+// predicate is unsatisfiable where the original was not, and a suite that
+// exercises either operand kills it. Refusing to GENERATE them would be the
+// wrong fix — that removes from the corpus mutants the suite ought to be asked
+// about, which is the one direction a mutation tool must never shrink in. What
+// is wrong is asking a style analyzer whether a mutant may be adjudicated at
+// all, so the analyzer is taken out of the loop instead. It also removes a vet
+// pass from every mutant's build, on a tool whose cost is dominated by builds.
+const vetOff = "-vet=off"
+
 func (m *mutantExecutor) getTestArgs(pkg string) []string {
-	args := []string{"test"}
+	args := []string{"test", vetOff}
 	if m.buildTags != "" {
-		args = append(args, "-tags", m.buildTags)
+		args = append(args, buildTagsFlag, m.buildTags)
 	}
 	// -timeout is the run-only leash, and it is deliberately the tighter of the
 	// two bounds: the Go toolchain starts it when the test binary starts, so a

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -70,14 +70,6 @@ const testTimeoutMarker = "panic: test timed out after "
 // indefinitely, which is the one hang the two time bounds below cannot catch.
 const outputDrainGrace = 2 * time.Second
 
-// buildFailureMarker and setupFailureMarker are what `go test` appends to the
-// FAIL line for a package whose test binary could not be built, or whose test
-// setup failed before any test ran. Both mean the mutant was never adjudicated.
-const (
-	buildFailureMarker = " [build failed]"
-	setupFailureMarker = " [setup failed]"
-)
-
 // ExecutorDealer is the initializer for new workerpool.Executor.
 type ExecutorDealer interface {
 	NewExecutor(mut mutator.Mutator, outCh chan<- mutator.Mutator, wg *sync.WaitGroup) workerpool.Executor
@@ -352,8 +344,15 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 // timeout, a build failure and an ordinary test failure all as exit status 1 —
 // only the test BINARY exits 2, and what we spawn is `go`. Taking that 1 at face
 // value would record a timed-out mutant as KILLED, crediting a detection that
-// never happened, and a mutant that does not compile as KILLED too. So the
-// child's output is scanned for the markers that tell the three apart.
+// never happened. So the child's output is scanned for the marker the test
+// binary prints when its own -timeout fires.
+//
+// A build failure is the third case sharing that exit status, and it is still
+// recorded as KILLED here. Separating it needs the mutators fixed as well as the
+// verdict — gremlins currently mutates the unary address-of `&` as if it were
+// bitwise AND, so `&Foo{}` becomes `|Foo{}` and a large share of a package's
+// mutants cannot compile at all. Classifying without removing them only moves
+// noise from one column to another. Tracked in cerberus issue #2930.
 func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime+m.compileAllowance)
 	defer cancel()
@@ -391,18 +390,11 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		// The timeout marker is checked first. A mutant that does not compile
-		// never runs a test binary, so it cannot print the timeout panic, and
-		// the orders only differ for a multi-package run where one package
-		// failed to build and another timed out. TIMED OUT is the safe verdict
-		// there: it stays in the efficacy denominator and credits nobody,
-		// whereas NOT VIABLE would drop the mutant out of the denominator
-		// altogether.
+		// TIMED OUT rather than the exit status: it stays in the efficacy
+		// denominator and credits nobody, whereas KILLED would pay the suite
+		// for a detection that never happened.
 		if scanner.sawTestTimeout() {
 			return mutator.TimedOut
-		}
-		if scanner.sawBuildFailure() {
-			return mutator.NotViable
 		}
 
 		return getTestFailedStatus(exitErr.ExitCode())
@@ -423,7 +415,7 @@ type outputScanner struct {
 }
 
 // scannedMarkers are the substrings outputScanner looks for.
-var scannedMarkers = []string{testTimeoutMarker, buildFailureMarker, setupFailureMarker}
+var scannedMarkers = []string{testTimeoutMarker}
 
 func newOutputScanner() *outputScanner {
 	carry := 0
@@ -467,12 +459,6 @@ func (s *outputScanner) saw(marker string) bool {
 // sawTestTimeout reports whether the test binary aborted on its own -timeout.
 func (s *outputScanner) sawTestTimeout() bool {
 	return s.saw(testTimeoutMarker)
-}
-
-// sawBuildFailure reports whether the package failed to build, or failed to set
-// up before any test ran. Either way the mutant was never adjudicated.
-func (s *outputScanner) sawBuildFailure() bool {
-	return s.saw(buildFailureMarker) || s.saw(setupFailureMarker)
 }
 
 // shutdownStatus returns the status to record for mutants that were
@@ -550,12 +536,12 @@ func run(ctx context.Context, cmd *exec.Cmd) error {
 	}
 }
 
-// getTestFailedStatus maps a non-zero exit status to a verdict. It is reached
-// only after runTests has ruled out the two statuses that `go test` also folds
-// into exit 1 — a test timeout and a build failure — so a 1 here really is a
-// failing test, which is a detection. Status 2 is what a test BINARY returns
-// when it panics; `go test` does not surface it, but a direct binary invocation
-// would, and it means the mutant was never adjudicated.
+// getTestFailedStatus maps a non-zero exit status to a verdict. runTests has
+// already taken the test timeouts out of exit 1 before reaching here; a build
+// failure still arrives as 1 and is still booked KILLED (cerberus issue #2930).
+// Status 2 is what a test BINARY returns when it panics; `go test` does not
+// surface it, but a direct binary invocation would, and it means the mutant was
+// never adjudicated.
 func getTestFailedStatus(exitCode int) mutator.Status {
 	switch exitCode {
 	case 1:

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -54,12 +54,21 @@ type ExecutorDealer interface {
 type MutantExecutorDealer struct {
 	wdDealer          workdir.Dealer
 	execContext       execContext
+	runCtx            context.Context
 	mod               gomodule.GoModule
 	buildTags         string
 	testExecutionTime time.Duration
 	dryRun            bool
 	integrationMode   bool
 	testCPU           int
+}
+
+// SetRunCtx wires the engine's root context into the dealer so that each
+// mutantExecutor it produces can observe cancellation (e.g. SIGTERM from
+// a CI runner) and mark in-flight mutants accordingly instead of falling
+// through to the default mutator.Lived branch.
+func (m *MutantExecutorDealer) SetRunCtx(ctx context.Context) {
+	m.runCtx = ctx
 }
 
 // ExecutorDealerOption is the defining option for the initialisation of a ExecutorDealer.
@@ -121,6 +130,10 @@ func NewExecutorDealer(mod gomodule.GoModule, wdd workdir.Dealer, elapsed time.D
 // will stream the results of the executor, and the wait group will be done when the
 // executor is complete.
 func (m MutantExecutorDealer) NewExecutor(mut mutator.Mutator, outCh chan<- mutator.Mutator, wg *sync.WaitGroup) workerpool.Executor {
+	runCtx := m.runCtx
+	if runCtx == nil {
+		runCtx = context.Background()
+	}
 	mj := mutantExecutor{
 		mutant:            mut,
 		outCh:             outCh,
@@ -133,6 +146,7 @@ func (m MutantExecutorDealer) NewExecutor(mut mutator.Mutator, outCh chan<- muta
 		execContext:       m.execContext,
 		testCPU:           m.testCPU,
 		testExecutionTime: m.testExecutionTime,
+		runCtx:            runCtx,
 	}
 
 	return &mj
@@ -146,6 +160,7 @@ type mutantExecutor struct {
 	outCh             chan<- mutator.Mutator
 	wg                *sync.WaitGroup
 	execContext       execContext
+	runCtx            context.Context
 	module            gomodule.GoModule
 	buildTags         string
 	testExecutionTime time.Duration
@@ -199,7 +214,11 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 }
 
 func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
-	ctx, cancel := context.WithTimeout(context.Background(), m.testExecutionTime)
+	// Root the test ctx in the engine's runCtx so that an external
+	// cancellation (e.g. SIGTERM from a CI runner) propagates into the
+	// `go test` subprocess and we can distinguish "the runner is shutting
+	// us down" from "the test ran past its deadline".
+	ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime)
 	defer cancel()
 
 	cmd := m.execContext(ctx, "go", m.getTestArgs(pkg)...)
@@ -218,12 +237,33 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return mutator.TimedOut
 	}
+	// If the parent runCtx was cancelled (Ctrl-C or runner SIGTERM) the
+	// `go test` child was killed before reaching a verdict. Reporting
+	// these as LIVED misrepresents the data — they were never tested.
+	// The configured shutdown status (default NotCovered) is the truthful
+	// outcome.
+	if m.runCtx.Err() != nil {
+		return shutdownStatus()
+	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		return getTestFailedStatus(exitErr.ExitCode())
 	}
 
 	return mutator.Lived
+}
+
+// shutdownStatus returns the status to record for mutants that were
+// in-flight when the run was cancelled. The choice is driven by the
+// `unleash.on-shutdown-status` config key (CLI flag
+// --on-shutdown-status). Unrecognised values fall back to NotCovered,
+// the truthful default ("we never finished running this mutant").
+func shutdownStatus() mutator.Status {
+	v := configuration.Get[string](configuration.UnleashOnShutdownStatusKey)
+	if s, ok := mutator.ParseShutdownStatus(v); ok {
+		return s
+	}
+	return mutator.NotCovered
 }
 
 func (m *mutantExecutor) getTestArgs(pkg string) []string {

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -38,6 +38,11 @@ import (
 // of each test run.
 const DefaultTimeoutCoefficient = 5
 
+// noTimeoutMax is the timeout ceiling meaning "no ceiling": the per-mutant
+// timeout is whatever the coefficient produces. This is the default, so the
+// behaviour of a run that does not set --timeout-max is unchanged.
+const noTimeoutMax = time.Duration(0)
+
 // ExecutorDealer is the initializer for new workerpool.Executor.
 type ExecutorDealer interface {
 	NewExecutor(mut mutator.Mutator, outCh chan<- mutator.Mutator, wg *sync.WaitGroup) workerpool.Executor
@@ -114,7 +119,7 @@ func NewExecutorDealer(mod gomodule.GoModule, wdd workdir.Dealer, elapsed time.D
 		dryRun:            dryRun,
 		integrationMode:   integrationMode,
 		testCPU:           testCPU,
-		testExecutionTime: baseTime * time.Duration(coefficient),
+		testExecutionTime: cappedExecutionTime(baseTime * time.Duration(coefficient)),
 		execContext:       exec.CommandContext,
 	}
 
@@ -123,6 +128,54 @@ func NewExecutorDealer(mod gomodule.GoModule, wdd workdir.Dealer, elapsed time.D
 	}
 
 	return &jd
+}
+
+// cappedExecutionTime clamps a coefficient-derived per-mutant timeout to the
+// absolute ceiling set by --timeout-max, if one is set.
+//
+// The coefficient-derived timeout is proportional to how long the package's own
+// tests take, which is unrelated to how much damage a runaway mutant can do in
+// that time. Mutating a loop-advance statement (i++ -> i--) inside a scanner
+// loop whose body appends per iteration produces a mutant that never terminates
+// and allocates until the machine is out of memory. On a CI runner the OOM
+// killer then reaps the runner agent itself, so the job dies with no verdict at
+// all — not a LIVED mutant, not a TIMED OUT one, just a dead runner. The
+// timeout is the only defence against that, and scaling it by test duration
+// hands the longest leash to the slowest-testing packages, which is backwards.
+//
+// A ceiling bounds the exposure independently of the baseline: past it the
+// mutant is killed and recorded as TIMED OUT, which is the honest verdict for a
+// mutant that did not terminate.
+//
+// Zero (the default) means no ceiling, so runs that do not set the flag behave
+// exactly as before. A malformed or non-positive value is reported and ignored
+// rather than silently treated as "no cap", because a safety ceiling that
+// quietly does nothing is worse than one that was never configured.
+func cappedExecutionTime(d time.Duration) time.Duration {
+	raw := configuration.Get[string](configuration.UnleashTimeoutMaxKey)
+	if raw == "" {
+		return d
+	}
+
+	max, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Errorf("invalid %s %q: %v; running without a timeout ceiling\n",
+			configuration.UnleashTimeoutMaxKey, raw, err)
+
+		return d
+	}
+	if max <= noTimeoutMax {
+		log.Errorf("invalid %s %q: must be positive; running without a timeout ceiling\n",
+			configuration.UnleashTimeoutMaxKey, raw)
+
+		return d
+	}
+
+	if d > max {
+		return max
+	}
+
+	return d
 }
 
 // NewExecutor returns a new workerpool.Executor for the given mutator.Mutator.

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -354,6 +354,16 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 // value would record a timed-out mutant as KILLED, crediting a detection that
 // never happened, and a mutant that does not compile as KILLED too. So the
 // child's output is scanned for the markers that tell the three apart.
+//
+// The two bounds also produce two DIFFERENT timeout verdicts, and the ordering
+// below is what keeps them apart. mutator.RunTimedOut is the only branch here
+// backed by a positive observation: the test binary printed, in its own output,
+// that the suite it was running overran the leash `go test -timeout` gave it.
+// Every other branch infers from an absence — a deadline that expired, a context
+// that was cancelled, an exit status that says nothing about which phase
+// produced it. mutator.TimedOut is that absence, and it must stay separate
+// precisely because a compile that hung reaches it identically to a run that
+// did.
 func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime+m.compileAllowance)
 	defer cancel()
@@ -378,6 +388,27 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 
 	err := run(ctx, cmd)
 
+	// The run-phase watchdog is read before either deadline, because it is
+	// evidence and they are the lack of it. Two things follow from that order.
+	//
+	// A goroutine dump from a runaway mutant can be large, and the backstop can
+	// expire while it is still draining; reading the backstop first would relabel
+	// the one mutant that DID report a verdict as one that did not. And a mutant
+	// that printed the marker before the runner's SIGTERM arrived was adjudicated
+	// by its own test binary before the shutdown, so the shutdown status would
+	// discard a verdict already reached.
+	//
+	// `err != nil` guards the marker: a package whose tests all pass exits 0, and
+	// a test that merely PRINTS this string while passing must not be read as one
+	// that overran. A binary the watchdog actually fired on always exits non-zero,
+	// and a deadline-killed child returns the context's error, so no real timeout
+	// is lost to the guard.
+	if err != nil && scanner.sawTestTimeout() {
+		return mutator.RunTimedOut
+	}
+	// The backstop bounds compile AND run together, so when it is what fired we
+	// do not know which phase spent it. Unadjudicated: it stays in the efficacy
+	// denominator and credits nobody.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return mutator.TimedOut
 	}
@@ -391,16 +422,12 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		// The timeout marker is checked first. A mutant that does not compile
-		// never runs a test binary, so it cannot print the timeout panic, and
-		// the orders only differ for a multi-package run where one package
-		// failed to build and another timed out. TIMED OUT is the safe verdict
-		// there: it stays in the efficacy denominator and credits nobody,
-		// whereas NOT VIABLE would drop the mutant out of the denominator
-		// altogether.
-		if scanner.sawTestTimeout() {
-			return mutator.TimedOut
-		}
+		// A mutant that does not compile never runs a test binary, so it cannot
+		// print the timeout panic and cannot have been claimed by the branch
+		// above; the two markers only compete for a multi-package run where one
+		// package failed to build and another timed out. RUN TIMED OUT is the
+		// safe verdict there, because NOT VIABLE would drop the mutant out of
+		// the denominator altogether.
 		if scanner.sawBuildFailure() {
 			return mutator.NotViable
 		}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,10 +39,44 @@ import (
 // of each test run.
 const DefaultTimeoutCoefficient = 5
 
-// noTimeoutMax is the timeout ceiling meaning "no ceiling": the per-mutant
-// timeout is whatever the coefficient produces. This is the default, so the
-// behaviour of a run that does not set --timeout-max is unchanged.
-const noTimeoutMax = time.Duration(0)
+// unsetDuration is the zero a duration setting reads as when it is absent or
+// rejected. Every reader of it applies its own fallback rather than using it as
+// a bound: a zero bound would kill every mutant instantly and report the
+// package as perfectly tested.
+const unsetDuration = time.Duration(0)
+
+// DefaultCompileAllowance is how long a mutant is allowed to COMPILE, over and
+// above the timeout that bounds its test run.
+//
+// The two bounds measure unrelated things. A package's compile time is a
+// property of its size and its dependency graph; a mutant's run time is a
+// property of the test that adjudicates it. Charging both to one number makes
+// the slow-compiling packages time out mutants that would have reached a
+// verdict in milliseconds. Two minutes is roughly four times the slowest
+// single-package compile observed on the projects this fork is used against
+// (~31s), which is headroom enough to be invisible in practice while still
+// bounding a compile that has genuinely hung.
+const DefaultCompileAllowance = 2 * time.Minute
+
+// testTimeoutMarker is the first thing the testing package prints when the
+// -timeout it was given expires. `go test` collapses a test timeout, a build
+// failure and an ordinary test failure into its own exit status 1, so the exit
+// code alone cannot tell them apart and the output has to.
+const testTimeoutMarker = "panic: test timed out after "
+
+// outputDrainGrace bounds how long Wait may block draining the child's output
+// pipes after the child itself has exited. Without it a grandchild that
+// inherited the pipe and outlived its parent would hold the executor open
+// indefinitely, which is the one hang the two time bounds below cannot catch.
+const outputDrainGrace = 2 * time.Second
+
+// buildFailureMarker and setupFailureMarker are what `go test` appends to the
+// FAIL line for a package whose test binary could not be built, or whose test
+// setup failed before any test ran. Both mean the mutant was never adjudicated.
+const (
+	buildFailureMarker = " [build failed]"
+	setupFailureMarker = " [setup failed]"
+)
 
 // ExecutorDealer is the initializer for new workerpool.Executor.
 type ExecutorDealer interface {
@@ -63,6 +98,7 @@ type MutantExecutorDealer struct {
 	mod               gomodule.GoModule
 	buildTags         string
 	testExecutionTime time.Duration
+	compileAllowance  time.Duration
 	dryRun            bool
 	integrationMode   bool
 	testCPU           int
@@ -120,6 +156,7 @@ func NewExecutorDealer(mod gomodule.GoModule, wdd workdir.Dealer, elapsed time.D
 		integrationMode:   integrationMode,
 		testCPU:           testCPU,
 		testExecutionTime: cappedExecutionTime(baseTime * time.Duration(coefficient)),
+		compileAllowance:  compileAllowance(),
 		execContext:       exec.CommandContext,
 	}
 
@@ -130,8 +167,8 @@ func NewExecutorDealer(mod gomodule.GoModule, wdd workdir.Dealer, elapsed time.D
 	return &jd
 }
 
-// cappedExecutionTime clamps a coefficient-derived per-mutant timeout to the
-// absolute ceiling set by --timeout-max, if one is set.
+// cappedExecutionTime clamps the coefficient-derived bound on a mutant's test
+// RUN to the absolute ceiling set by --timeout-max, if one is set.
 //
 // The coefficient-derived timeout is proportional to how long the package's own
 // tests take, which is unrelated to how much damage a runaway mutant can do in
@@ -152,22 +189,8 @@ func NewExecutorDealer(mod gomodule.GoModule, wdd workdir.Dealer, elapsed time.D
 // rather than silently treated as "no cap", because a safety ceiling that
 // quietly does nothing is worse than one that was never configured.
 func cappedExecutionTime(d time.Duration) time.Duration {
-	raw := configuration.Get[string](configuration.UnleashTimeoutMaxKey)
-	if raw == "" {
-		return d
-	}
-
-	max, err := time.ParseDuration(raw)
-	if err != nil {
-		log.Errorf("invalid %s %q: %v; running without a timeout ceiling\n",
-			configuration.UnleashTimeoutMaxKey, raw, err)
-
-		return d
-	}
-	if max <= noTimeoutMax {
-		log.Errorf("invalid %s %q: must be positive; running without a timeout ceiling\n",
-			configuration.UnleashTimeoutMaxKey, raw)
-
+	max, ok := positiveDuration(configuration.UnleashTimeoutMaxKey, "running without a timeout ceiling")
+	if !ok {
 		return d
 	}
 
@@ -176,6 +199,47 @@ func cappedExecutionTime(d time.Duration) time.Duration {
 	}
 
 	return d
+}
+
+// compileAllowance returns the time a mutant is allowed to compile, on top of
+// the bound on its test run. It is configured with --compile-allowance and
+// falls back to DefaultCompileAllowance.
+func compileAllowance() time.Duration {
+	d, ok := positiveDuration(configuration.UnleashCompileAllowanceKey, "using the default compile allowance")
+	if !ok {
+		return DefaultCompileAllowance
+	}
+
+	return d
+}
+
+// positiveDuration reads a Go duration from a string configuration key. It
+// reports ok=false when the key is unset, unparseable, or non-positive, so the
+// caller applies its own fallback.
+//
+// A malformed value is reported and ignored rather than silently treated as
+// zero: a zero bound would kill every mutant instantly and report the package
+// as perfectly tested. onInvalid names what the caller will do instead, so the
+// message says what actually happens rather than only what did not.
+func positiveDuration(key, onInvalid string) (time.Duration, bool) {
+	raw := configuration.Get[string](key)
+	if raw == "" {
+		return unsetDuration, false
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Errorf("invalid %s %q: %v; %s\n", key, raw, err, onInvalid)
+
+		return unsetDuration, false
+	}
+	if d <= unsetDuration {
+		log.Errorf("invalid %s %q: must be positive; %s\n", key, raw, onInvalid)
+
+		return unsetDuration, false
+	}
+
+	return d, true
 }
 
 // NewExecutor returns a new workerpool.Executor for the given mutator.Mutator.
@@ -199,6 +263,7 @@ func (m MutantExecutorDealer) NewExecutor(mut mutator.Mutator, outCh chan<- muta
 		execContext:       m.execContext,
 		testCPU:           m.testCPU,
 		testExecutionTime: m.testExecutionTime,
+		compileAllowance:  m.compileAllowance,
 		runCtx:            runCtx,
 	}
 
@@ -217,6 +282,7 @@ type mutantExecutor struct {
 	module            gomodule.GoModule
 	buildTags         string
 	testExecutionTime time.Duration
+	compileAllowance  time.Duration
 	dryRun            bool
 	integrationMode   bool
 	testCPU           int
@@ -229,9 +295,9 @@ type mutantExecutor struct {
 // run the tests and mark the TokenMutator as either KILLED or LIVED depending
 // on the result. If the tests pass, it means the TokenMutator survived, so it
 // will be LIVED, if the tests fail, the TokenMutator will be KILLED.
-// The timeout of the test is managed outside the run of the test, using
-// a context with timeout. This is done because the Go test command doesn't
-// make it easy to distinguish failures from timeouts.
+// A mutant is bounded twice: `go test -timeout` bounds the test RUN, and a
+// context deadline bounds compilation and the run together as a backstop. See
+// runTests for why the two are separate.
 func (m *mutantExecutor) Start(w *workerpool.Worker) {
 	defer m.wg.Done()
 	workerName := fmt.Sprintf("%s-%d", w.Name, w.ID)
@@ -266,12 +332,30 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 	m.outCh <- m.mutant
 }
 
+// runTests runs the mutated package's tests and classifies the outcome.
+//
+// Two bounds, because there are two things to bound and they scale
+// independently:
+//
+//   - `go test -timeout` (m.testExecutionTime) bounds the test RUN. The Go
+//     toolchain starts that clock when the test binary starts, so compiling the
+//     mutated package does not consume it. This is the leash that matters: it is
+//     what stops a mutant that never terminates.
+//   - The context deadline (run bound + compile allowance) bounds compilation
+//     and the run together. No -timeout can bound a compile that hangs, because
+//     no test binary exists yet to enforce it, so the context stays as the
+//     backstop. It is also rooted in the engine's runCtx, so an external
+//     cancellation (e.g. SIGTERM from a CI runner) propagates into the child and
+//     we can tell "the runner is shutting us down" from "this mutant ran long".
+//
+// Classification cannot go on the exit status alone. `go test` reports a test
+// timeout, a build failure and an ordinary test failure all as exit status 1 —
+// only the test BINARY exits 2, and what we spawn is `go`. Taking that 1 at face
+// value would record a timed-out mutant as KILLED, crediting a detection that
+// never happened, and a mutant that does not compile as KILLED too. So the
+// child's output is scanned for the markers that tell the three apart.
 func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
-	// Root the test ctx in the engine's runCtx so that an external
-	// cancellation (e.g. SIGTERM from a CI runner) propagates into the
-	// `go test` subprocess and we can distinguish "the runner is shutting
-	// us down" from "the test ran past its deadline".
-	ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime)
+	ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime+m.compileAllowance)
 	defer cancel()
 
 	cmd := m.execContext(ctx, "go", m.getTestArgs(pkg)...)
@@ -281,6 +365,13 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	}
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GOTMPDIR=%s", m.wdDealer.WorkDir()))
+
+	// The output is scanned, never retained: a runaway mutant can print without
+	// bound, and buffering that would trade one resource exhaustion for another.
+	scanner := newOutputScanner()
+	cmd.Stdout = scanner
+	cmd.Stderr = scanner
+	cmd.WaitDelay = outputDrainGrace
 
 	// Set up process group for killing entire process tree
 	setupProcessGroup(cmd)
@@ -300,10 +391,88 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
+		// The timeout marker is checked first. A mutant that does not compile
+		// never runs a test binary, so it cannot print the timeout panic, and
+		// the orders only differ for a multi-package run where one package
+		// failed to build and another timed out. TIMED OUT is the safe verdict
+		// there: it stays in the efficacy denominator and credits nobody,
+		// whereas NOT VIABLE would drop the mutant out of the denominator
+		// altogether.
+		if scanner.sawTestTimeout() {
+			return mutator.TimedOut
+		}
+		if scanner.sawBuildFailure() {
+			return mutator.NotViable
+		}
+
 		return getTestFailedStatus(exitErr.ExitCode())
 	}
 
 	return mutator.Lived
+}
+
+// outputScanner is an io.Writer that watches a stream for fixed markers and
+// then throws it away. It retains only enough bytes to recognise a marker split
+// across two writes, so its memory use is constant however much the child
+// prints.
+type outputScanner struct {
+	mu    sync.Mutex
+	tail  string
+	seen  map[string]bool
+	carry int
+}
+
+// scannedMarkers are the substrings outputScanner looks for.
+var scannedMarkers = []string{testTimeoutMarker, buildFailureMarker, setupFailureMarker}
+
+func newOutputScanner() *outputScanner {
+	carry := 0
+	for _, marker := range scannedMarkers {
+		if len(marker) > carry {
+			carry = len(marker)
+		}
+	}
+
+	return &outputScanner{seen: make(map[string]bool, len(scannedMarkers)), carry: carry - 1}
+}
+
+func (s *outputScanner) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	window := s.tail + string(p)
+	for _, marker := range scannedMarkers {
+		if strings.Contains(window, marker) {
+			s.seen[marker] = true
+		}
+	}
+
+	// Retain just enough of the tail that a marker straddling two writes is
+	// still recognised on the next one.
+	if len(window) > s.carry {
+		window = window[len(window)-s.carry:]
+	}
+	s.tail = window
+
+	return len(p), nil
+}
+
+func (s *outputScanner) saw(marker string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.seen[marker]
+}
+
+// sawTestTimeout reports whether the test binary aborted on its own -timeout.
+func (s *outputScanner) sawTestTimeout() bool {
+	return s.saw(testTimeoutMarker)
+}
+
+// sawBuildFailure reports whether the package failed to build, or failed to set
+// up before any test ran. Either way the mutant was never adjudicated.
+func (s *outputScanner) sawBuildFailure() bool {
+	return s.saw(buildFailureMarker) || s.saw(setupFailureMarker)
 }
 
 // shutdownStatus returns the status to record for mutants that were
@@ -324,10 +493,11 @@ func (m *mutantExecutor) getTestArgs(pkg string) []string {
 	if m.buildTags != "" {
 		args = append(args, "-tags", m.buildTags)
 	}
-	// Here we add some seconds to the timeout to be sure it's gremlins that catches the test
-	// timeout and not the test itself. The timeout on the test prevents the test.* processes
-	// from hanging forever.
-	args = append(args, "-timeout", (2*time.Second + m.testExecutionTime).String())
+	// -timeout is the run-only leash, and it is deliberately the tighter of the
+	// two bounds: the Go toolchain starts it when the test binary starts, so a
+	// slow compile cannot eat it. The context deadline in runTests sits above it
+	// and covers compilation as well.
+	args = append(args, "-timeout", m.testExecutionTime.String())
 	args = append(args, "-failfast")
 
 	if m.testCPU != 0 {
@@ -380,6 +550,12 @@ func run(ctx context.Context, cmd *exec.Cmd) error {
 	}
 }
 
+// getTestFailedStatus maps a non-zero exit status to a verdict. It is reached
+// only after runTests has ruled out the two statuses that `go test` also folds
+// into exit 1 — a test timeout and a build failure — so a 1 here really is a
+// failing test, which is a detection. Status 2 is what a test BINARY returns
+// when it panics; `go test` does not surface it, but a direct binary invocation
+// would, and it means the mutant was never adjudicated.
 func getTestFailedStatus(exitCode int) mutator.Status {
 	switch exitCode {
 	case 1:

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -70,6 +70,14 @@ const testTimeoutMarker = "panic: test timed out after "
 // indefinitely, which is the one hang the two time bounds below cannot catch.
 const outputDrainGrace = 2 * time.Second
 
+// buildFailureMarker and setupFailureMarker are what `go test` appends to the
+// FAIL line for a package whose test binary could not be built, or whose test
+// setup failed before any test ran. Both mean the mutant was never adjudicated.
+const (
+	buildFailureMarker = " [build failed]"
+	setupFailureMarker = " [setup failed]"
+)
+
 // ExecutorDealer is the initializer for new workerpool.Executor.
 type ExecutorDealer interface {
 	NewExecutor(mut mutator.Mutator, outCh chan<- mutator.Mutator, wg *sync.WaitGroup) workerpool.Executor
@@ -344,15 +352,8 @@ func (m *mutantExecutor) Start(w *workerpool.Worker) {
 // timeout, a build failure and an ordinary test failure all as exit status 1 —
 // only the test BINARY exits 2, and what we spawn is `go`. Taking that 1 at face
 // value would record a timed-out mutant as KILLED, crediting a detection that
-// never happened. So the child's output is scanned for the marker the test
-// binary prints when its own -timeout fires.
-//
-// A build failure is the third case sharing that exit status, and it is still
-// recorded as KILLED here. Separating it needs the mutators fixed as well as the
-// verdict — gremlins currently mutates the unary address-of `&` as if it were
-// bitwise AND, so `&Foo{}` becomes `|Foo{}` and a large share of a package's
-// mutants cannot compile at all. Classifying without removing them only moves
-// noise from one column to another. Tracked in cerberus issue #2930.
+// never happened, and a mutant that does not compile as KILLED too. So the
+// child's output is scanned for the markers that tell the three apart.
 func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	ctx, cancel := context.WithTimeout(m.runCtx, m.testExecutionTime+m.compileAllowance)
 	defer cancel()
@@ -390,11 +391,18 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		// TIMED OUT rather than the exit status: it stays in the efficacy
-		// denominator and credits nobody, whereas KILLED would pay the suite
-		// for a detection that never happened.
+		// The timeout marker is checked first. A mutant that does not compile
+		// never runs a test binary, so it cannot print the timeout panic, and
+		// the orders only differ for a multi-package run where one package
+		// failed to build and another timed out. TIMED OUT is the safe verdict
+		// there: it stays in the efficacy denominator and credits nobody,
+		// whereas NOT VIABLE would drop the mutant out of the denominator
+		// altogether.
 		if scanner.sawTestTimeout() {
 			return mutator.TimedOut
+		}
+		if scanner.sawBuildFailure() {
+			return mutator.NotViable
 		}
 
 		return getTestFailedStatus(exitErr.ExitCode())
@@ -415,7 +423,7 @@ type outputScanner struct {
 }
 
 // scannedMarkers are the substrings outputScanner looks for.
-var scannedMarkers = []string{testTimeoutMarker}
+var scannedMarkers = []string{testTimeoutMarker, buildFailureMarker, setupFailureMarker}
 
 func newOutputScanner() *outputScanner {
 	carry := 0
@@ -459,6 +467,12 @@ func (s *outputScanner) saw(marker string) bool {
 // sawTestTimeout reports whether the test binary aborted on its own -timeout.
 func (s *outputScanner) sawTestTimeout() bool {
 	return s.saw(testTimeoutMarker)
+}
+
+// sawBuildFailure reports whether the package failed to build, or failed to set
+// up before any test ran. Either way the mutant was never adjudicated.
+func (s *outputScanner) sawBuildFailure() bool {
+	return s.saw(buildFailureMarker) || s.saw(setupFailureMarker)
 }
 
 // shutdownStatus returns the status to record for mutants that were
@@ -536,12 +550,12 @@ func run(ctx context.Context, cmd *exec.Cmd) error {
 	}
 }
 
-// getTestFailedStatus maps a non-zero exit status to a verdict. runTests has
-// already taken the test timeouts out of exit 1 before reaching here; a build
-// failure still arrives as 1 and is still booked KILLED (cerberus issue #2930).
-// Status 2 is what a test BINARY returns when it panics; `go test` does not
-// surface it, but a direct binary invocation would, and it means the mutant was
-// never adjudicated.
+// getTestFailedStatus maps a non-zero exit status to a verdict. It is reached
+// only after runTests has ruled out the two statuses that `go test` also folds
+// into exit 1 — a test timeout and a build failure — so a 1 here really is a
+// failing test, which is a detection. Status 2 is what a test BINARY returns
+// when it panics; `go test` does not surface it, but a direct binary invocation
+// would, and it means the mutant was never adjudicated.
 func getTestFailedStatus(exitCode int) mutator.Status {
 	switch exitCode {
 	case 1:

--- a/internal/engine/executor_internal_test.go
+++ b/internal/engine/executor_internal_test.go
@@ -123,27 +123,40 @@ func TestOutputScanner(t *testing.T) {
 			if !sut.sawTestTimeout() {
 				t.Fatalf("marker split after %d bytes went unnoticed", i)
 			}
+			if sut.sawBuildFailure() {
+				t.Fatalf("marker split after %d bytes was also read as a build failure", i)
+			}
 		}
 	})
 
-	t.Run("the other exit-1 outcomes trip nothing", func(t *testing.T) {
+	t.Run("recognises a build failure and a setup failure", func(t *testing.T) {
 		t.Parallel()
 
-		// Both of these leave `go test`'s exit status 1 to speak for itself. A
-		// failing test is a detection and belongs there; a build failure is not,
-		// and is the subject of cerberus issue #2930.
 		for name, output := range map[string]string{
-			"a failing test": "--- FAIL: TestX (0.00s)\n    x_test.go:9: boom\n" +
-				"FAIL\texample.com/pkg\t0.005s\n",
-			"a build failure": "# example.com/pkg [example.com/pkg.test]\n" +
+			"build": "# example.com/pkg [example.com/pkg.test]\n" +
 				"./x.go:5:2: undefined: missing\nFAIL\texample.com/pkg [build failed]\n",
+			"setup": "FAIL\texample.com/pkg [setup failed]\n",
 		} {
 			sut := newOutputScanner()
 			mustWrite(t, sut, output)
 
-			if sut.sawTestTimeout() {
-				t.Errorf("%s was read as a timeout", name)
+			if !sut.sawBuildFailure() {
+				t.Errorf("%s failure went unnoticed", name)
 			}
+			if sut.sawTestTimeout() {
+				t.Errorf("%s failure was also read as a timeout", name)
+			}
+		}
+	})
+
+	t.Run("an ordinary failure trips neither marker", func(t *testing.T) {
+		t.Parallel()
+
+		sut := newOutputScanner()
+		mustWrite(t, sut, "--- FAIL: TestX (0.00s)\n    x_test.go:9: boom\nFAIL\texample.com/pkg\t0.005s\n")
+
+		if sut.sawTestTimeout() || sut.sawBuildFailure() {
+			t.Error("a failing test must be left to the exit status, which makes it a detection")
 		}
 	})
 

--- a/internal/engine/executor_internal_test.go
+++ b/internal/engine/executor_internal_test.go
@@ -17,6 +17,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -37,42 +38,42 @@ func TestGetTestArgs(t *testing.T) {
 		"should_not_include_tags_flag_when_build_tags_are_empty": {
 			testExecutionTime: 10 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_include_tags_flag_when_build_tags_are_set": {
 			buildTags:         "tag1,tag2",
 			testExecutionTime: 10 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-tags", "tag1,tag2", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-tags", "tag1,tag2", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
-		"should_compute_timeout_as_two_seconds_plus_execution_time": {
+		"should_pass_the_run_bound_verbatim_so_compile_time_is_not_charged_to_it": {
 			testExecutionTime: 30 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "32s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "30s", "-failfast", "example.com/my/package"},
 		},
 		"should_not_include_cpu_flag_when_test_cpu_is_zero": {
 			testExecutionTime: 10 * time.Second,
 			testCPU:           0,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_include_cpu_flag_when_test_cpu_is_nonzero": {
 			testExecutionTime: 10 * time.Second,
 			testCPU:           4,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "-cpu", "4", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "10s", "-failfast", "-cpu", "4", "example.com/my/package"},
 		},
 		"should_use_package_path_when_integration_mode_is_disabled": {
 			testExecutionTime: 10 * time.Second,
 			integrationMode:   false,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_use_dot_dot_dot_path_when_integration_mode_is_enabled": {
 			testExecutionTime: 10 * time.Second,
 			integrationMode:   true,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "./..."},
+			want:              []string{"test", "-timeout", "10s", "-failfast", "./..."},
 		},
 		"should_include_all_flags_when_all_options_are_configured": {
 			buildTags:         "integration",
@@ -80,7 +81,7 @@ func TestGetTestArgs(t *testing.T) {
 			testCPU:           2,
 			integrationMode:   true,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-tags", "integration", "-timeout", "12s", "-failfast", "-cpu", "2", "./..."},
+			want:              []string{"test", "-tags", "integration", "-timeout", "10s", "-failfast", "-cpu", "2", "./..."},
 		},
 	}
 
@@ -99,5 +100,89 @@ func TestGetTestArgs(t *testing.T) {
 				t.Errorf("getTestArgs() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestOutputScanner pins the two properties the verdict classification depends
+// on: a marker is recognised however the child's output happens to be chunked,
+// and the scanner never grows with the volume it is fed.
+func TestOutputScanner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("recognises a marker split across writes", func(t *testing.T) {
+		t.Parallel()
+
+		// The pipe between `go test` and gremlins chunks at whatever boundary
+		// the kernel chooses, so the marker is split at every offset in turn
+		// rather than at one arbitrary place.
+		for i := 1; i < len(testTimeoutMarker); i++ {
+			sut := newOutputScanner()
+			mustWrite(t, sut, "some earlier output\n"+testTimeoutMarker[:i])
+			mustWrite(t, sut, testTimeoutMarker[i:]+"10s\n\ngoroutine 1 [running]:\n")
+
+			if !sut.sawTestTimeout() {
+				t.Fatalf("marker split after %d bytes went unnoticed", i)
+			}
+			if sut.sawBuildFailure() {
+				t.Fatalf("marker split after %d bytes was also read as a build failure", i)
+			}
+		}
+	})
+
+	t.Run("recognises a build failure and a setup failure", func(t *testing.T) {
+		t.Parallel()
+
+		for name, output := range map[string]string{
+			"build": "# example.com/pkg [example.com/pkg.test]\n" +
+				"./x.go:5:2: undefined: missing\nFAIL\texample.com/pkg [build failed]\n",
+			"setup": "FAIL\texample.com/pkg [setup failed]\n",
+		} {
+			sut := newOutputScanner()
+			mustWrite(t, sut, output)
+
+			if !sut.sawBuildFailure() {
+				t.Errorf("%s failure went unnoticed", name)
+			}
+			if sut.sawTestTimeout() {
+				t.Errorf("%s failure was also read as a timeout", name)
+			}
+		}
+	})
+
+	t.Run("an ordinary failure trips neither marker", func(t *testing.T) {
+		t.Parallel()
+
+		sut := newOutputScanner()
+		mustWrite(t, sut, "--- FAIL: TestX (0.00s)\n    x_test.go:9: boom\nFAIL\texample.com/pkg\t0.005s\n")
+
+		if sut.sawTestTimeout() || sut.sawBuildFailure() {
+			t.Error("a failing test must be left to the exit status, which makes it a detection")
+		}
+	})
+
+	t.Run("retains a constant amount however much it is fed", func(t *testing.T) {
+		t.Parallel()
+
+		// A runaway mutant can print without bound; buffering that output would
+		// trade the resource exhaustion this fork exists to prevent for another.
+		sut := newOutputScanner()
+		const chunk = 64 * 1024
+		const chunks = 64
+		for i := 0; i < chunks; i++ {
+			mustWrite(t, sut, strings.Repeat("x", chunk))
+		}
+
+		if len(sut.tail) > sut.carry {
+			t.Errorf("retained %d bytes after %d, want at most %d", len(sut.tail), chunk*chunks, sut.carry)
+		}
+	})
+}
+
+func mustWrite(t *testing.T, sut *outputScanner, s string) {
+	t.Helper()
+
+	n, err := sut.Write([]byte(s))
+	if err != nil || n != len(s) {
+		t.Fatalf("Write(%d bytes) = %d, %v", len(s), n, err)
 	}
 }

--- a/internal/engine/executor_internal_test.go
+++ b/internal/engine/executor_internal_test.go
@@ -123,40 +123,27 @@ func TestOutputScanner(t *testing.T) {
 			if !sut.sawTestTimeout() {
 				t.Fatalf("marker split after %d bytes went unnoticed", i)
 			}
-			if sut.sawBuildFailure() {
-				t.Fatalf("marker split after %d bytes was also read as a build failure", i)
-			}
 		}
 	})
 
-	t.Run("recognises a build failure and a setup failure", func(t *testing.T) {
+	t.Run("the other exit-1 outcomes trip nothing", func(t *testing.T) {
 		t.Parallel()
 
+		// Both of these leave `go test`'s exit status 1 to speak for itself. A
+		// failing test is a detection and belongs there; a build failure is not,
+		// and is the subject of cerberus issue #2930.
 		for name, output := range map[string]string{
-			"build": "# example.com/pkg [example.com/pkg.test]\n" +
+			"a failing test": "--- FAIL: TestX (0.00s)\n    x_test.go:9: boom\n" +
+				"FAIL\texample.com/pkg\t0.005s\n",
+			"a build failure": "# example.com/pkg [example.com/pkg.test]\n" +
 				"./x.go:5:2: undefined: missing\nFAIL\texample.com/pkg [build failed]\n",
-			"setup": "FAIL\texample.com/pkg [setup failed]\n",
 		} {
 			sut := newOutputScanner()
 			mustWrite(t, sut, output)
 
-			if !sut.sawBuildFailure() {
-				t.Errorf("%s failure went unnoticed", name)
-			}
 			if sut.sawTestTimeout() {
-				t.Errorf("%s failure was also read as a timeout", name)
+				t.Errorf("%s was read as a timeout", name)
 			}
-		}
-	})
-
-	t.Run("an ordinary failure trips neither marker", func(t *testing.T) {
-		t.Parallel()
-
-		sut := newOutputScanner()
-		mustWrite(t, sut, "--- FAIL: TestX (0.00s)\n    x_test.go:9: boom\nFAIL\texample.com/pkg\t0.005s\n")
-
-		if sut.sawTestTimeout() || sut.sawBuildFailure() {
-			t.Error("a failing test must be left to the exit status, which makes it a detection")
 		}
 	})
 

--- a/internal/engine/executor_internal_test.go
+++ b/internal/engine/executor_internal_test.go
@@ -38,42 +38,42 @@ func TestGetTestArgs(t *testing.T) {
 		"should_not_include_tags_flag_when_build_tags_are_empty": {
 			testExecutionTime: 10 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "10s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-vet=off", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_include_tags_flag_when_build_tags_are_set": {
 			buildTags:         "tag1,tag2",
 			testExecutionTime: 10 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-tags", "tag1,tag2", "-timeout", "10s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-vet=off", "-tags", "tag1,tag2", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_pass_the_run_bound_verbatim_so_compile_time_is_not_charged_to_it": {
 			testExecutionTime: 30 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "30s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-vet=off", "-timeout", "30s", "-failfast", "example.com/my/package"},
 		},
 		"should_not_include_cpu_flag_when_test_cpu_is_zero": {
 			testExecutionTime: 10 * time.Second,
 			testCPU:           0,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "10s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-vet=off", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_include_cpu_flag_when_test_cpu_is_nonzero": {
 			testExecutionTime: 10 * time.Second,
 			testCPU:           4,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "10s", "-failfast", "-cpu", "4", "example.com/my/package"},
+			want:              []string{"test", "-vet=off", "-timeout", "10s", "-failfast", "-cpu", "4", "example.com/my/package"},
 		},
 		"should_use_package_path_when_integration_mode_is_disabled": {
 			testExecutionTime: 10 * time.Second,
 			integrationMode:   false,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "10s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-vet=off", "-timeout", "10s", "-failfast", "example.com/my/package"},
 		},
 		"should_use_dot_dot_dot_path_when_integration_mode_is_enabled": {
 			testExecutionTime: 10 * time.Second,
 			integrationMode:   true,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "10s", "-failfast", "./..."},
+			want:              []string{"test", "-vet=off", "-timeout", "10s", "-failfast", "./..."},
 		},
 		"should_include_all_flags_when_all_options_are_configured": {
 			buildTags:         "integration",
@@ -81,7 +81,7 @@ func TestGetTestArgs(t *testing.T) {
 			testCPU:           2,
 			integrationMode:   true,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-tags", "integration", "-timeout", "10s", "-failfast", "-cpu", "2", "./..."},
+			want:              []string{"test", "-vet=off", "-tags", "integration", "-timeout", "10s", "-failfast", "-cpu", "2", "./..."},
 		},
 	}
 

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -398,7 +398,7 @@ func TestMutatorRun(t *testing.T) {
 			if tc.wantExecutionTime != 0 {
 				wantRunBound = tc.wantExecutionTime
 			}
-			want := fmt.Sprintf("go test -tags %s -timeout %s -failfast %s", tc.tags, wantRunBound, tc.wantPath)
+			want := fmt.Sprintf("go test -vet=off -tags %s -timeout %s -failfast %s", tc.tags, wantRunBound, tc.wantPath)
 			got := fmt.Sprintf("go %v", strings.Join(holder.args, " "))
 
 			if !cmp.Equal(got, want) {

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -151,6 +151,18 @@ func TestMutatorTestExecution(t *testing.T) {
 			mutantStatus:  mutator.Runnable,
 			wantMutStatus: mutator.NotViable,
 		},
+		{
+			// The run-phase timeout marker is evidence only alongside a child
+			// that FAILED. A child that printed it and then exited 0 adjudicated
+			// the mutant, whatever it said on the way, and reading its output
+			// alone would move a survivor out of the LIVED column and into a
+			// timeout one — where a consumer that credits run-phase timeouts
+			// would then pay the suite for it.
+			name:          "if the child prints the timeout marker and still succeeds, mutation is LIVED",
+			testResult:    fakeExecCommandMarkerThenSuccess,
+			mutantStatus:  mutator.Runnable,
+			wantMutStatus: mutator.Lived,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -538,6 +550,16 @@ func TestProcessTestsFailure(_ *testing.T) {
 	os.Exit(1) // skipcq: RVV-A0003
 }
 
+// TestProcessMarkerThenSuccess is the child-process entry point that prints the
+// bytes a timed-out test binary prints and then exits 0.
+func TestProcessMarkerThenSuccess(_ *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, "panic: test timed out after 10m0s")
+	os.Exit(0) // skipcq: RVV-A0003
+}
+
 func TestProcessBuildFailure(_ *testing.T) {
 	if os.Getenv("GO_TEST_PROCESS") != "1" {
 		return
@@ -760,6 +782,13 @@ func fakeExecCommandWithHolder(got *commandHolder, fakeCmd func(ctx context.Cont
 
 func fakeExecCommandTestsFailure(ctx context.Context, command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestProcessTestsFailure", "--", command}
+	cs = append(cs, args...)
+
+	return getCmd(ctx, cs)
+}
+
+func fakeExecCommandMarkerThenSuccess(ctx context.Context, command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestProcessMarkerThenSuccess", "--", command}
 	cs = append(cs, args...)
 
 	return getCmd(ctx, cs)

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -442,6 +442,90 @@ func TestProcessBuildFailure(_ *testing.T) {
 	os.Exit(2) // skipcq: RVV-A0003
 }
 
+// TestProcessSleep is the child-process entry point used by the
+// SIGTERM-shutdown tests: it sleeps long enough that the parent ctx
+// will cancel it. ExecCommandContext kills the process tree on ctx
+// cancellation, so this child will exit non-zero (signal kill) and
+// the parent ctx.Err() will be non-nil.
+func TestProcessSleep(_ *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
+	os.Exit(0) // skipcq: RVV-A0003 — only reached if no one cancels us
+}
+
+func fakeExecCommandSleep(ctx context.Context, command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestProcessSleep", "--", command}
+	cs = append(cs, args...)
+	return getCmd(ctx, cs)
+}
+
+// TestShutdownMidRun pins the fix for the bug where a SIGTERM from a CI
+// runner during `gremlins unleash` caused mutants that were still being
+// tested to be recorded as LIVED. The expected behaviour now: when the
+// engine's root ctx is cancelled mid-run, in-flight mutants are reported
+// with the status configured via --on-shutdown-status (default
+// not-run -> mutator.NotCovered), never LIVED.
+func TestShutdownMidRun(t *testing.T) {
+	cases := []struct {
+		name       string
+		flagValue  string
+		wantStatus mutator.Status
+	}{
+		{name: "default not-run maps to NotCovered", flagValue: "not-run", wantStatus: mutator.NotCovered},
+		{name: "timed-out maps to TimedOut", flagValue: "timed-out", wantStatus: mutator.TimedOut},
+		{name: "lived preserves legacy behaviour for opt-in", flagValue: "lived", wantStatus: mutator.Lived},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			viperSet(map[string]any{
+				configuration.UnleashDryRunKey:           false,
+				configuration.UnleashOnShutdownStatusKey: tc.flagValue,
+			})
+			defer viperReset()
+
+			wdDealer := newWdDealerStub(t)
+			mod := gomodule.GoModule{Name: "example.com", Root: ".", CallingDir: "."}
+			mjd := engine.NewExecutorDealer(mod, wdDealer, expectedTimeout,
+				engine.WithExecContext(fakeExecCommandSleep),
+			)
+			runCtx, cancel := context.WithCancel(context.Background())
+			mjd.SetRunCtx(runCtx)
+
+			mut := &mutantStub{
+				status:  mutator.Runnable,
+				mutType: mutator.ConditionalsBoundary,
+				pkg:     "example.com",
+			}
+			outCh := make(chan mutator.Mutator, 1)
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			executor := mjd.NewExecutor(mut, outCh, &wg)
+			w := &workerpool.Worker{Name: "test", ID: 1}
+
+			// Cancel the run a short moment after the executor starts, so
+			// the test subprocess is killed mid-flight.
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				cancel()
+			}()
+			executor.Start(w)
+			wg.Wait()
+
+			select {
+			case got := <-outCh:
+				if got.Status() != tc.wantStatus {
+					t.Fatalf("shutdown-mid-run: want %v, got %v", tc.wantStatus, got.Status())
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("executor never wrote to outCh")
+			}
+		})
+	}
+}
+
 func TestMutatorRunInTheCorrectFolder(t *testing.T) {
 	t.Run("mutation should run in the correct folder", func(t *testing.T) {
 		callingDir := "test/dir"

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -235,6 +235,7 @@ func TestMutatorRun(t *testing.T) {
 		tags               string
 		wantPath           string
 		timeoutMax         string
+		compileAllowance   string
 		timeoutCoefficient int
 		// wantExecutionTime, when non-zero, is the per-mutant timeout the run
 		// must end up with, overriding the coefficient-derived expectation.
@@ -312,6 +313,32 @@ func TestMutatorRun(t *testing.T) {
 			tags:              "tag1,t1g2",
 			wantPath:          "example.com/my/package",
 		},
+		{
+			// The compile allowance moves the context deadline and must leave
+			// the run bound alone: it buys time for compiling, not for running.
+			name:             "compile-allowance extends the deadline but not the run bound",
+			compileAllowance: "3m",
+			pkg:              "example.com/my/package",
+			callDir:          "test/dir",
+			tags:             "tag1,t1g2",
+			wantPath:         "example.com/my/package",
+		},
+		{
+			name:             "a malformed compile-allowance falls back to the default",
+			compileAllowance: "three minutes",
+			pkg:              "example.com/my/package",
+			callDir:          "test/dir",
+			tags:             "tag1,t1g2",
+			wantPath:         "example.com/my/package",
+		},
+		{
+			name:             "a non-positive compile-allowance falls back to the default",
+			compileAllowance: "0s",
+			pkg:              "example.com/my/package",
+			callDir:          "test/dir",
+			tags:             "tag1,t1g2",
+			wantPath:         "example.com/my/package",
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -325,6 +352,9 @@ func TestMutatorRun(t *testing.T) {
 			}
 			if tc.timeoutMax != "" {
 				settings[configuration.UnleashTimeoutMaxKey] = tc.timeoutMax
+			}
+			if tc.compileAllowance != "" {
+				settings[configuration.UnleashCompileAllowanceKey] = tc.compileAllowance
 			}
 			viperSet(settings)
 			defer viperReset()
@@ -358,24 +388,40 @@ func TestMutatorRun(t *testing.T) {
 			executor.Start(w)
 			wg.Wait()
 
-			wantTimeout := 2*time.Second + expectedTimeout*engine.DefaultTimeoutCoefficient
+			// -timeout carries the run bound verbatim. Nothing is added to it:
+			// the whole point is that the leash Go enforces on the test RUN is
+			// the tighter of the two bounds, so a slow compile cannot eat it.
+			wantRunBound := expectedTimeout * engine.DefaultTimeoutCoefficient
 			if tc.timeoutCoefficient != 0 {
-				wantTimeout = 2*time.Second + expectedTimeout*time.Duration(tc.timeoutCoefficient)
+				wantRunBound = expectedTimeout * time.Duration(tc.timeoutCoefficient)
 			}
 			if tc.wantExecutionTime != 0 {
-				wantTimeout = 2*time.Second + tc.wantExecutionTime
+				wantRunBound = tc.wantExecutionTime
 			}
-			want := fmt.Sprintf("go test -tags %s -timeout %s -failfast %s", tc.tags, wantTimeout, tc.wantPath)
+			want := fmt.Sprintf("go test -tags %s -timeout %s -failfast %s", tc.tags, wantRunBound, tc.wantPath)
 			got := fmt.Sprintf("go %v", strings.Join(holder.args, " "))
 
 			if !cmp.Equal(got, want) {
 				t.Errorf("\n+ %s\n- %s\n", got, want)
 			}
 
-			timeoutDifference := absTimeDiff(holder.timeout, expectedTimeout*2)
-			diffThreshold := 100 * time.Second
-			if timeoutDifference > diffThreshold {
-				t.Errorf("expected timeout to be within %s from the set timeout, got %s", diffThreshold, timeoutDifference)
+			// The context deadline is the backstop: the run bound PLUS the
+			// compile allowance, so compilation is charged to it and not to the
+			// run bound above.
+			wantAllowance := engine.DefaultCompileAllowance
+			if tc.compileAllowance != "" {
+				parsed, err := time.ParseDuration(tc.compileAllowance)
+				if err == nil && parsed > 0 {
+					wantAllowance = parsed
+				}
+			}
+			wantDeadline := wantRunBound + wantAllowance
+			// The deadline is read after the context is created, so a little of
+			// it has already elapsed; only scheduling slack is tolerated.
+			const deadlineSlack = 2 * time.Second
+			if d := absTimeDiff(holder.timeout, wantDeadline); d > deadlineSlack {
+				t.Errorf("expected the context deadline to be %s (run bound %s + compile allowance %s), got %s",
+					wantDeadline, wantRunBound, wantAllowance, holder.timeout)
 			}
 		})
 	}

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -234,8 +234,12 @@ func TestMutatorRun(t *testing.T) {
 		callDir            string
 		tags               string
 		wantPath           string
+		timeoutMax         string
 		timeoutCoefficient int
-		intMode            bool
+		// wantExecutionTime, when non-zero, is the per-mutant timeout the run
+		// must end up with, overriding the coefficient-derived expectation.
+		wantExecutionTime time.Duration
+		intMode           bool
 	}{
 		{
 			name:     "normal mode",
@@ -261,6 +265,53 @@ func TestMutatorRun(t *testing.T) {
 			tags:               "tag1,t1g2",
 			wantPath:           "example.com/my/package",
 		},
+		{
+			// The whole point of the ceiling: 4 x 10s would be 40s, and a mutant
+			// that never terminates gets 40s to exhaust the machine. The cap
+			// takes it to 15s regardless of how slow the package's tests are.
+			name:               "it caps the timeout at timeout-max",
+			timeoutCoefficient: 4,
+			timeoutMax:         "15s",
+			wantExecutionTime:  15 * time.Second,
+			pkg:                "example.com/my/package",
+			callDir:            "test/dir",
+			tags:               "tag1,t1g2",
+			wantPath:           "example.com/my/package",
+		},
+		{
+			// A ceiling above the derived timeout must not pull it UP: the cap
+			// bounds the worst case, it does not set the timeout.
+			name:               "a timeout-max above the derived timeout leaves it alone",
+			timeoutCoefficient: 4,
+			timeoutMax:         "2m",
+			wantExecutionTime:  40 * time.Second,
+			pkg:                "example.com/my/package",
+			callDir:            "test/dir",
+			tags:               "tag1,t1g2",
+			wantPath:           "example.com/my/package",
+		},
+		{
+			// An unparseable ceiling falls back to the derived timeout. It is
+			// reported on stderr rather than swallowed, but it must not abort a
+			// run or silently become zero — a zero timeout would kill every
+			// mutant instantly and report the package as perfectly tested.
+			name:              "a malformed timeout-max is ignored",
+			timeoutMax:        "fifteen seconds",
+			wantExecutionTime: expectedTimeout * engine.DefaultTimeoutCoefficient,
+			pkg:               "example.com/my/package",
+			callDir:           "test/dir",
+			tags:              "tag1,t1g2",
+			wantPath:          "example.com/my/package",
+		},
+		{
+			name:              "a non-positive timeout-max is ignored",
+			timeoutMax:        "0s",
+			wantExecutionTime: expectedTimeout * engine.DefaultTimeoutCoefficient,
+			pkg:               "example.com/my/package",
+			callDir:           "test/dir",
+			tags:              "tag1,t1g2",
+			wantPath:          "example.com/my/package",
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -271,6 +322,9 @@ func TestMutatorRun(t *testing.T) {
 			}
 			if tc.timeoutCoefficient != 0 {
 				settings[configuration.UnleashTimeoutCoefficientKey] = tc.timeoutCoefficient
+			}
+			if tc.timeoutMax != "" {
+				settings[configuration.UnleashTimeoutMaxKey] = tc.timeoutMax
 			}
 			viperSet(settings)
 			defer viperReset()
@@ -307,6 +361,9 @@ func TestMutatorRun(t *testing.T) {
 			wantTimeout := 2*time.Second + expectedTimeout*engine.DefaultTimeoutCoefficient
 			if tc.timeoutCoefficient != 0 {
 				wantTimeout = 2*time.Second + expectedTimeout*time.Duration(tc.timeoutCoefficient)
+			}
+			if tc.wantExecutionTime != 0 {
+				wantTimeout = 2*time.Second + tc.wantExecutionTime
 			}
 			want := fmt.Sprintf("go test -tags %s -timeout %s -failfast %s", tc.tags, wantTimeout, tc.wantPath)
 			got := fmt.Sprintf("go %v", strings.Join(holder.args, " "))

--- a/internal/engine/executor_verdict_test.go
+++ b/internal/engine/executor_verdict_test.go
@@ -32,10 +32,10 @@ import (
 
 // These tests drive the REAL `go` toolchain rather than a stubbed exec, because
 // the thing under test is precisely how gremlins reads what `go test` reports.
-// A stub could be made to say anything; only the real command shows that a
+// A stub could be made to say anything; only the real command proves that a
 // timed-out mutant, a mutant that does not compile and a mutant that is killed
-// all arrive as the same exit status 1, so a stub asserting exit codes would be
-// asserting a fiction.
+// are told apart. `go test` gives all three the same exit status 1, so a stub
+// asserting exit codes would be asserting a fiction.
 
 // baselineElapsed is the "how long the package's own tests take" figure fed to
 // NewExecutorDealer, and runBoundCoefficient multiplies it. Together they put
@@ -213,19 +213,10 @@ func TestVerdictsFromRealGoTest(t *testing.T) {
 			want: mutator.Killed,
 		},
 		{
-			// The case the timeout classification must not swallow, pinned at
-			// the verdict it actually reaches rather than the one it deserves.
-			// `go test` exits 1 for a build failure exactly as it does for a
-			// failing test, so this mutant is booked KILLED — the suite
-			// credited for a detection against source a compiler rejected.
-			//
-			// Separating it needs the mutators fixed as well as the verdict:
-			// gremlins mutates the unary address-of `&` as if it were bitwise
-			// AND, so `&Foo{}` becomes `|Foo{}` and a large share of a
-			// package's mutants cannot compile at all. Classifying without
-			// removing them moves noise between columns. Tracked in cerberus
-			// issue #2930; this case is what turns red when it is fixed.
-			name: "a mutant that does not compile still reaches the exit-status path",
+			// The case the timeout classification must not swallow. `go test`
+			// exits 1 here, exactly as it does for a failing test, so reading
+			// the exit status alone would credit a detection that never ran.
+			name: "a mutant that does not compile is NOT VIABLE",
 			fx: goTestFixture{
 				sources: map[string]string{
 					"verdict.go":      uncompilableSource,
@@ -234,13 +225,13 @@ func TestVerdictsFromRealGoTest(t *testing.T) {
 				runBound:         "60s",
 				compileAllowance: generousCompileAllowance,
 			},
-			want: mutator.Killed,
+			want: mutator.NotViable,
 		},
 		{
 			// The run-only leash firing. TIMED OUT stays in the efficacy
-			// denominator and credits nobody; KILLED — which is where the exit
-			// status alone would put it, as the case above shows — would credit
-			// a detection that never happened.
+			// denominator and credits nobody; KILLED would credit a detection
+			// that never happened, and NOT VIABLE would drop the mutant out of
+			// the denominator altogether.
 			name: "a test that does not terminate is TIMED OUT",
 			fx: goTestFixture{
 				sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": nonTerminatingTest},

--- a/internal/engine/executor_verdict_test.go
+++ b/internal/engine/executor_verdict_test.go
@@ -19,6 +19,7 @@ package engine_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -67,6 +68,13 @@ type goTestFixture struct {
 	// unambiguously slow. Without it the toolchain answers from cache and the
 	// compile phase is too fast to say anything about.
 	coldCache bool
+	// supervisor, when non-empty, is the body of a `go test -exec` shell script
+	// interposed in front of the test binary. It models the external memory
+	// supervisor cerberus wires in (.github/scripts/mutant-memory-guard.mjs),
+	// which kills a mutant that breaches a resident-memory ceiling and then
+	// HOLDS rather than exiting, so that no exit status of its own can be read
+	// as a verdict.
+	supervisor string
 }
 
 // runMutant applies the fixture and returns the verdict the executor reached,
@@ -82,6 +90,19 @@ func runMutant(t *testing.T, fx goTestFixture) (mutator.Status, time.Duration) {
 
 	if fx.coldCache {
 		t.Setenv("GOCACHE", t.TempDir())
+	}
+
+	if fx.supervisor != "" {
+		// -exec is reached through GOFLAGS because the executor builds the
+		// `go test` argv itself, which is exactly how cerberus wires its guard
+		// in. GOFLAGS is space-separated with no quoting, so the path may not
+		// contain whitespace.
+		guard := filepath.Join(t.TempDir(), "supervisor.sh")
+		writeExecutable(t, guard, fx.supervisor)
+		if strings.ContainsAny(guard, " \t") {
+			t.Fatalf("the supervisor path contains whitespace, which GOFLAGS cannot express: %s", guard)
+		}
+		t.Setenv("GOFLAGS", "-exec="+guard)
 	}
 
 	settings := map[string]any{
@@ -116,6 +137,16 @@ func runMutant(t *testing.T, fx goTestFixture) (mutator.Status, time.Duration) {
 		t.Fatal("executor never wrote a verdict")
 
 		return mutator.NotCovered, elapsed
+	}
+}
+
+// writeExecutable writes a shell script and marks it runnable. Separate from
+// writeFile because the mode is the whole point.
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
 	}
 }
 
@@ -228,17 +259,19 @@ func TestVerdictsFromRealGoTest(t *testing.T) {
 			want: mutator.NotViable,
 		},
 		{
-			// The run-only leash firing. TIMED OUT stays in the efficacy
-			// denominator and credits nobody; KILLED would credit a detection
-			// that never happened, and NOT VIABLE would drop the mutant out of
-			// the denominator altogether.
-			name: "a test that does not terminate is TIMED OUT",
+			// The run-only leash firing, reported by the test binary itself.
+			// RUN TIMED OUT is the one verdict here backed by a positive
+			// observation about the mutant rather than by a deadline expiring
+			// around it, which is why it is a status of its own: a consumer that
+			// cannot tell it from the compile backstop cannot tell a
+			// non-terminating mutant from a slow compiler.
+			name: "a test that does not terminate is RUN TIMED OUT",
 			fx: goTestFixture{
 				sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": nonTerminatingTest},
 				runBound:         "1s",
 				compileAllowance: generousCompileAllowance,
 			},
-			want: mutator.TimedOut,
+			want: mutator.RunTimedOut,
 		},
 	}
 
@@ -293,8 +326,70 @@ func TestCompileIsNotChargedToTheRunBound(t *testing.T) {
 			coldCache:        true,
 		})
 
+		// TIMED OUT, emphatically not RUN TIMED OUT: no test binary existed,
+		// so nothing observed the mutant at all. Collapsing the two here is how
+		// a hung compile would get paid as a detection.
 		if got != mutator.TimedOut {
 			t.Errorf("expected TIMED OUT from the compile backstop, got %v", got)
+		}
+	})
+}
+
+// reapingSupervisor models .github/scripts/mutant-memory-guard.mjs in cerberus:
+// it starts the test binary, kills it as a resident-memory breach would, and
+// then HOLDS without ever exiting. Holding is the guard's whole design — every
+// exit status it could produce is one `go test` collapses into its own exit 1,
+// which would be read as a KILL — so the mutant has to be claimed by a deadline
+// instead. The reapWait gives the binary time to be running before it is killed,
+// and the hold is long enough that only the backstop can end this mutant.
+const reapingSupervisor = `#!/bin/sh
+"$@" &
+child=$!
+sleep 1
+kill -9 "$child" 2>/dev/null
+wait "$child" 2>/dev/null
+sleep 3600
+`
+
+// TestAReapedMutantIsNotCreditedAsARunTimeout is the boundary that makes
+// crediting a run-phase timeout safe (cerberus #2921, #2944).
+//
+// An external supervisor that kills a mutant for breaching a memory ceiling
+// destroys the very evidence RUN TIMED OUT is made of: no test binary survives
+// to print its own timeout panic. The mutant is therefore claimed by the
+// compile+run backstop, exactly like a hung compile, and stays unadjudicated.
+//
+// The two halves share one fixture and differ only in whether the supervisor is
+// interposed, so the contrast is the mechanism itself rather than two unrelated
+// scenarios. Without the supervisor the run watchdog fires and the verdict is
+// RUN TIMED OUT; with it, the same mutant is TIMED OUT.
+func TestAReapedMutantIsNotCreditedAsARunTimeout(t *testing.T) {
+	fixture := func(supervisor string) goTestFixture {
+		return goTestFixture{
+			sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": nonTerminatingTest},
+			runBound:         "3s",
+			compileAllowance: "2s",
+			supervisor:       supervisor,
+		}
+	}
+
+	t.Run("unsupervised, the run watchdog claims it", func(t *testing.T) {
+		got, _ := runMutant(t, fixture(""))
+		if got != mutator.RunTimedOut {
+			t.Fatalf("expected RUN TIMED OUT from the run watchdog, got %v — without this half the case"+
+				" below proves nothing, because it could not tell a reaped mutant from an unreachable one", got)
+		}
+	})
+
+	t.Run("reaped before the watchdog, the backstop claims it", func(t *testing.T) {
+		got, _ := runMutant(t, fixture(reapingSupervisor))
+		if got == mutator.RunTimedOut {
+			t.Fatalf("a mutant killed by an external memory supervisor was credited as a run-phase" +
+				" timeout: no test binary lived long enough to report anything, so this is the compile" +
+				" backstop wearing a detection's name")
+		}
+		if got != mutator.TimedOut {
+			t.Fatalf("expected TIMED OUT for a reaped mutant, got %v", got)
 		}
 	})
 }

--- a/internal/engine/executor_verdict_test.go
+++ b/internal/engine/executor_verdict_test.go
@@ -32,10 +32,10 @@ import (
 
 // These tests drive the REAL `go` toolchain rather than a stubbed exec, because
 // the thing under test is precisely how gremlins reads what `go test` reports.
-// A stub could be made to say anything; only the real command proves that a
+// A stub could be made to say anything; only the real command shows that a
 // timed-out mutant, a mutant that does not compile and a mutant that is killed
-// are told apart. `go test` gives all three the same exit status 1, so a stub
-// asserting exit codes would be asserting a fiction.
+// all arrive as the same exit status 1, so a stub asserting exit codes would be
+// asserting a fiction.
 
 // baselineElapsed is the "how long the package's own tests take" figure fed to
 // NewExecutorDealer, and runBoundCoefficient multiplies it. Together they put
@@ -213,10 +213,19 @@ func TestVerdictsFromRealGoTest(t *testing.T) {
 			want: mutator.Killed,
 		},
 		{
-			// The case the timeout classification must not swallow. `go test`
-			// exits 1 here, exactly as it does for a failing test, so reading
-			// the exit status alone would credit a detection that never ran.
-			name: "a mutant that does not compile is NOT VIABLE",
+			// The case the timeout classification must not swallow, pinned at
+			// the verdict it actually reaches rather than the one it deserves.
+			// `go test` exits 1 for a build failure exactly as it does for a
+			// failing test, so this mutant is booked KILLED — the suite
+			// credited for a detection against source a compiler rejected.
+			//
+			// Separating it needs the mutators fixed as well as the verdict:
+			// gremlins mutates the unary address-of `&` as if it were bitwise
+			// AND, so `&Foo{}` becomes `|Foo{}` and a large share of a
+			// package's mutants cannot compile at all. Classifying without
+			// removing them moves noise between columns. Tracked in cerberus
+			// issue #2930; this case is what turns red when it is fixed.
+			name: "a mutant that does not compile still reaches the exit-status path",
 			fx: goTestFixture{
 				sources: map[string]string{
 					"verdict.go":      uncompilableSource,
@@ -225,13 +234,13 @@ func TestVerdictsFromRealGoTest(t *testing.T) {
 				runBound:         "60s",
 				compileAllowance: generousCompileAllowance,
 			},
-			want: mutator.NotViable,
+			want: mutator.Killed,
 		},
 		{
 			// The run-only leash firing. TIMED OUT stays in the efficacy
-			// denominator and credits nobody; KILLED would credit a detection
-			// that never happened, and NOT VIABLE would drop the mutant out of
-			// the denominator altogether.
+			// denominator and credits nobody; KILLED — which is where the exit
+			// status alone would put it, as the case above shows — would credit
+			// a detection that never happened.
 			name: "a test that does not terminate is TIMED OUT",
 			fx: goTestFixture{
 				sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": nonTerminatingTest},

--- a/internal/engine/executor_verdict_test.go
+++ b/internal/engine/executor_verdict_test.go
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-gremlins/gremlins/internal/configuration"
+	"github.com/go-gremlins/gremlins/internal/engine"
+	"github.com/go-gremlins/gremlins/internal/engine/workerpool"
+	"github.com/go-gremlins/gremlins/internal/gomodule"
+	"github.com/go-gremlins/gremlins/internal/mutator"
+)
+
+// These tests drive the REAL `go` toolchain rather than a stubbed exec, because
+// the thing under test is precisely how gremlins reads what `go test` reports.
+// A stub could be made to say anything; only the real command proves that a
+// timed-out mutant, a mutant that does not compile and a mutant that is killed
+// are told apart. `go test` gives all three the same exit status 1, so a stub
+// asserting exit codes would be asserting a fiction.
+
+// baselineElapsed is the "how long the package's own tests take" figure fed to
+// NewExecutorDealer, and runBoundCoefficient multiplies it. Together they put
+// the coefficient-derived leash far above any ceiling a case sets, so each
+// fixture's --timeout-max IS its run bound and no case depends on the
+// coefficient arithmetic by accident.
+const (
+	baselineElapsed     = time.Second
+	runBoundCoefficient = 3600
+)
+
+// generousCompileAllowance is large enough that no case here is adjudicated by
+// the backstop except the one that means to be.
+const generousCompileAllowance = "5m"
+
+// noCompileAllowance is the smallest positive allowance the flag accepts. Paired
+// with a short run bound it makes the backstop the binding constraint, which is
+// how the compile-phase bound is exercised.
+const noCompileAllowance = "1ms"
+
+type goTestFixture struct {
+	// sources maps a file name inside the throwaway module to its content.
+	sources map[string]string
+	// runBound is the value --timeout-max clamps the run leash to.
+	runBound string
+	// compileAllowance is the value of --compile-allowance.
+	compileAllowance string
+	// coldCache forces a private, empty build cache so compilation is
+	// unambiguously slow. Without it the toolchain answers from cache and the
+	// compile phase is too fast to say anything about.
+	coldCache bool
+}
+
+// runMutant applies the fixture and returns the verdict the executor reached,
+// along with how long the whole invocation took.
+func runMutant(t *testing.T, fx goTestFixture) (mutator.Status, time.Duration) {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", "module gremlinsverdict\n\ngo 1.25\n")
+	for name, content := range fx.sources {
+		writeFile(t, dir, name, content)
+	}
+
+	if fx.coldCache {
+		t.Setenv("GOCACHE", t.TempDir())
+	}
+
+	settings := map[string]any{
+		configuration.UnleashDryRunKey:             false,
+		configuration.UnleashTimeoutMaxKey:         fx.runBound,
+		configuration.UnleashCompileAllowanceKey:   fx.compileAllowance,
+		configuration.UnleashOnShutdownStatusKey:   "not-run",
+		configuration.UnleashTimeoutCoefficientKey: runBoundCoefficient,
+	}
+	viperSet(settings)
+	defer viperReset()
+
+	wdDealer := &dealerStub{fnGet: func(string) (string, error) { return dir, nil }}
+	mod := gomodule.GoModule{Name: "gremlinsverdict", Root: dir, CallingDir: "."}
+	mjd := engine.NewExecutorDealer(mod, wdDealer, baselineElapsed)
+
+	mut := &mutantStub{status: mutator.Runnable, mutType: mutator.ConditionalsBoundary, pkg: "."}
+	outCh := make(chan mutator.Mutator, 1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	executor := mjd.NewExecutor(mut, outCh, &wg)
+
+	start := time.Now()
+	executor.Start(&workerpool.Worker{Name: "test", ID: 1})
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	select {
+	case got := <-outCh:
+		return got.Status(), elapsed
+	default:
+		t.Fatal("executor never wrote a verdict")
+
+		return mutator.NotCovered, elapsed
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+// baseSource is the mutated code under test. Every fixture carries a non-test
+// source file, because that is where a mutant lives.
+const baseSource = `package verdict
+
+func Answer() int { return 42 }
+`
+
+const passingTest = `package verdict
+
+import "testing"
+
+func TestPasses(t *testing.T) {
+	if Answer() != 42 {
+		t.Fatal("unexpected")
+	}
+}
+`
+
+const failingTest = `package verdict
+
+import "testing"
+
+func TestFails(t *testing.T) {
+	if Answer() == 42 {
+		t.Fatal("the mutant was detected")
+	}
+}
+`
+
+const nonTerminatingTest = `package verdict
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNeverTerminates(t *testing.T) {
+	_ = Answer()
+	time.Sleep(time.Hour)
+}
+`
+
+const uncompilableSource = `package verdict
+
+func Broken() int { return thisSymbolDoesNotExist() }
+`
+
+const uncompilableTest = `package verdict
+
+import "testing"
+
+func TestBroken(t *testing.T) { _ = Broken() }
+`
+
+// TestVerdictsFromRealGoTest pins each of the four outcomes independently.
+// `go test` reports a failing test, a build failure and a test timeout all as
+// exit status 1 — only the test BINARY exits 2, and what gremlins spawns is
+// `go` — so any of the three could be mistaken for either of the others. Each
+// direction is proven here rather than inferred from the others.
+func TestVerdictsFromRealGoTest(t *testing.T) {
+	testCases := []struct {
+		name string
+		fx   goTestFixture
+		want mutator.Status
+	}{
+		{
+			// The mutant survived: nothing about it made a test fail.
+			name: "a passing test suite LIVES",
+			fx: goTestFixture{
+				sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": passingTest},
+				runBound:         "60s",
+				compileAllowance: generousCompileAllowance,
+			},
+			want: mutator.Lived,
+		},
+		{
+			// A genuine detection, and the only outcome that may be credited.
+			name: "a failing test KILLS",
+			fx: goTestFixture{
+				sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": failingTest},
+				runBound:         "60s",
+				compileAllowance: generousCompileAllowance,
+			},
+			want: mutator.Killed,
+		},
+		{
+			// The case the timeout classification must not swallow. `go test`
+			// exits 1 here, exactly as it does for a failing test, so reading
+			// the exit status alone would credit a detection that never ran.
+			name: "a mutant that does not compile is NOT VIABLE",
+			fx: goTestFixture{
+				sources: map[string]string{
+					"verdict.go":      uncompilableSource,
+					"verdict_test.go": uncompilableTest,
+				},
+				runBound:         "60s",
+				compileAllowance: generousCompileAllowance,
+			},
+			want: mutator.NotViable,
+		},
+		{
+			// The run-only leash firing. TIMED OUT stays in the efficacy
+			// denominator and credits nobody; KILLED would credit a detection
+			// that never happened, and NOT VIABLE would drop the mutant out of
+			// the denominator altogether.
+			name: "a test that does not terminate is TIMED OUT",
+			fx: goTestFixture{
+				sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": nonTerminatingTest},
+				runBound:         "1s",
+				compileAllowance: generousCompileAllowance,
+			},
+			want: mutator.TimedOut,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := runMutant(t, tc.fx)
+			if got != tc.want {
+				t.Errorf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestCompileIsNotChargedToTheRunBound is the fix itself, stated as behaviour.
+//
+// Both halves compile the same package with an empty build cache, so
+// compilation demonstrably outlasts the run bound. With a compile allowance the
+// mutant is adjudicated on its test, which passes in microseconds; without one
+// the backstop fires. Before the split there was no allowance to give, and the
+// first half was a TIMED OUT mutant that had never run a line of test code.
+func TestCompileIsNotChargedToTheRunBound(t *testing.T) {
+	const runBound = 2 * time.Second
+
+	t.Run("a compile longer than the run bound still lets the test decide", func(t *testing.T) {
+		got, elapsed := runMutant(t, goTestFixture{
+			sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": passingTest},
+			runBound:         runBound.String(),
+			compileAllowance: generousCompileAllowance,
+			coldCache:        true,
+		})
+
+		// Without this the case could pass vacuously on a machine where the
+		// cold compile happened to fit inside the run bound, proving nothing.
+		if elapsed <= runBound {
+			t.Fatalf("cold compile took %s, which is inside the %s run bound: this case cannot"+
+				" distinguish a run-only bound from a compile-and-run one", elapsed, runBound)
+		}
+		if got != mutator.Lived {
+			t.Errorf("expected LIVED after a %s compile against a %s run bound, got %v", elapsed, runBound, got)
+		}
+	})
+
+	t.Run("the backstop still bounds a compile that outlives it", func(t *testing.T) {
+		// No -timeout can bound a compile: there is no test binary yet to
+		// enforce one. The context deadline is the only thing that can, and it
+		// must still report the honest verdict for an unadjudicated mutant.
+		got, _ := runMutant(t, goTestFixture{
+			sources:          map[string]string{"verdict.go": baseSource, "verdict_test.go": passingTest},
+			runBound:         "100ms",
+			compileAllowance: noCompileAllowance,
+			coldCache:        true,
+		})
+
+		if got != mutator.TimedOut {
+			t.Errorf("expected TIMED OUT from the compile backstop, got %v", got)
+		}
+	})
+}

--- a/internal/engine/mappings.go
+++ b/internal/engine/mappings.go
@@ -23,7 +23,9 @@ import (
 )
 
 // TokenMutantType is the mapping from each token.Token and all the
-// mutator.Type that can be applied to it.
+// mutator.Type that can be applied to it, read as the INFIX meaning of the
+// token. A token read in prefix position goes through MutantTypesFor, which
+// filters this table by unaryMutableOperators.
 var TokenMutantType = map[token.Token][]mutator.Type{
 	token.ADD:            {mutator.ArithmeticBase},
 	token.ADD_ASSIGN:     {mutator.InvertAssignments, mutator.RemoveSelfAssignments},
@@ -59,6 +61,46 @@ var TokenMutantType = map[token.Token][]mutator.Type{
 	token.SUB_ASSIGN:     {mutator.InvertAssignments, mutator.RemoveSelfAssignments},
 	token.XOR:            {mutator.InvertBitwise},
 	token.XOR_ASSIGN:     {mutator.RemoveSelfAssignments, mutator.InvertBitwiseAssignments},
+}
+
+// unaryMutableOperators are the prefix operators of an *ast.UnaryExpr whose
+// TokenMutantType entry may be applied as written. Go spells `+`, `-`, `&` and
+// `^` the same in prefix and infix position and means something different by
+// each, while TokenMutantType describes the infix meaning:
+//
+//   - `+x` and `-x` are the sign of a value, the same arithmetic their infix
+//     spellings perform, so ARITHMETIC_BASE and INVERT_NEGATIVES carry over
+//     unchanged: `-x` becomes `+x` and `+x` becomes `-x`, both of which are
+//     Go, and both of which change what the expression evaluates to.
+//   - `&x` is address-of, not bitwise AND. INVERT_BITWISE rewrites it to `|x`,
+//     which is not an expression at all: the compiler answers
+//     `syntax error: unexpected |, expected expression`.
+//   - `^x` is bitwise complement, not XOR. INVERT_BITWISE rewrites it to `&x`,
+//     which takes the operand's address and therefore no longer has the
+//     operand's type: `cannot use &u (value of type *uint) as uint value`.
+//
+// The last two are not mutants that a test suite failed to catch, they are
+// source a compiler rejected, so every verdict they can be given misdescribes
+// the suite. They are not generated rather than generated and reclassified:
+// reclassifying leaves the same numerator and denominator as never generating
+// them, but leaves a package's mutant set full of entries that mean nothing.
+var unaryMutableOperators = map[token.Token]bool{
+	token.ADD: true,
+	token.SUB: true,
+}
+
+// MutantTypesFor returns the mutator.Type set that may be applied to node. It
+// reports false when node's token carries no mutation in the position it was
+// read in -- either because the token has no TokenMutantType entry at all, or
+// because it is a prefix operator outside unaryMutableOperators.
+func MutantTypesFor(node *NodeToken) ([]mutator.Type, bool) {
+	if node.IsUnary() && !unaryMutableOperators[node.Tok()] {
+		return nil, false
+	}
+
+	mutantTypes, ok := TokenMutantType[node.Tok()]
+
+	return mutantTypes, ok
 }
 
 var tokenMutations = map[mutator.Type]map[token.Token]token.Token{

--- a/internal/engine/node.go
+++ b/internal/engine/node.go
@@ -26,6 +26,7 @@ import (
 type NodeToken struct {
 	tok    *token.Token
 	TokPos token.Pos
+	unary  bool
 }
 
 // NewTokenNode checks if the ast.Node implementation is supported by
@@ -35,6 +36,7 @@ type NodeToken struct {
 func NewTokenNode(n ast.Node) (*NodeToken, bool) {
 	var tok *token.Token
 	var pos token.Pos
+	var unary bool
 	switch n := n.(type) {
 	case *ast.AssignStmt:
 		tok = &n.Tok
@@ -51,6 +53,7 @@ func NewTokenNode(n ast.Node) (*NodeToken, bool) {
 	case *ast.UnaryExpr:
 		tok = &n.Op
 		pos = n.OpPos
+		unary = true
 	default:
 		return &NodeToken{}, false
 	}
@@ -58,7 +61,17 @@ func NewTokenNode(n ast.Node) (*NodeToken, bool) {
 	return &NodeToken{
 		tok:    tok,
 		TokPos: pos,
+		unary:  unary,
 	}, true
+}
+
+// IsUnary reports whether the token was read as the prefix operator of an
+// *ast.UnaryExpr rather than as an infix operator or a statement token. Go
+// spells four operators the same in both positions -- `+`, `-`, `&` and `^` --
+// and means something different by each, so the position a token was read in
+// decides which mutations may be applied to it. See unaryMutableOperators.
+func (n *NodeToken) IsUnary() bool {
+	return n.unary
 }
 
 // Tok returns the reference to the token.Token.

--- a/internal/engine/testdata/fixtures/unary_and_go
+++ b/internal/engine/testdata/fixtures/unary_and_go
@@ -1,0 +1,9 @@
+package main
+
+type point struct {
+	x int
+}
+
+func main() {
+	_ = &point{x: 1}
+}

--- a/internal/engine/testdata/fixtures/unary_xor_go
+++ b/internal/engine/testdata/fixtures/unary_xor_go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	var u uint = 1
+	_ = ^u
+}

--- a/internal/engine/unary_mutation_test.go
+++ b/internal/engine/unary_mutation_test.go
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/go-gremlins/gremlins/internal/configuration"
+	"github.com/go-gremlins/gremlins/internal/engine"
+	"github.com/go-gremlins/gremlins/internal/gomodule"
+	"github.com/go-gremlins/gremlins/internal/mutator"
+)
+
+// Go spells `+`, `-`, `&` and `^` the same in prefix and infix position and
+// means something different by each. Mutating a prefix `&` as if it were
+// bitwise AND turns `&Foo{}` into `|Foo{}`, which does not parse; mutating a
+// prefix `^` the same way turns `^u` into `&u`, which no longer has the
+// operand's type. Neither is a fault a test suite could have caught, so
+// neither is generated.
+
+func TestUnaryOperatorsAreNotMutatedAsBinaryOnes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		fixture string
+		// want is the mutator.Type the fixture's single operator must yield,
+		// or the zero Type when the fixture must yield no mutant at all.
+		want     mutator.Type
+		mutating bool
+	}{
+		{
+			name:     "a prefix & is address-of, not bitwise AND",
+			fixture:  "testdata/fixtures/unary_and_go",
+			mutating: false,
+		},
+		{
+			name:     "a prefix ^ is complement, not XOR",
+			fixture:  "testdata/fixtures/unary_xor_go",
+			mutating: false,
+		},
+		{
+			name:     "an infix & is still INVERT_BITWISE",
+			fixture:  "testdata/fixtures/and_go",
+			want:     mutator.InvertBitwise,
+			mutating: true,
+		},
+		{
+			name:     "an infix ^ is still INVERT_BITWISE",
+			fixture:  "testdata/fixtures/xor_go",
+			want:     mutator.InvertBitwise,
+			mutating: true,
+		},
+		{
+			name:     "a prefix - is still INVERT_NEGATIVES",
+			fixture:  "testdata/fixtures/negative_sub_go",
+			want:     mutator.InvertNegatives,
+			mutating: true,
+		},
+		{
+			name:     "an infix + is still ARITHMETIC_BASE",
+			fixture:  "testdata/fixtures/add_go",
+			want:     mutator.ArithmeticBase,
+			mutating: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			viperSet(map[string]any{configuration.UnleashDryRunKey: true})
+			defer viperReset()
+
+			mapFS, mod, c := loadFixture(tc.fixture, ".")
+			defer c()
+
+			mut := engine.New(mod, engine.CodeData{}, newJobDealerStub(t), engine.WithDirFs(mapFS))
+			got := mut.Run(context.Background()).Mutants
+
+			if !tc.mutating {
+				if len(got) != 0 {
+					t.Fatalf("expected no mutant, got %d: %s", len(got), describe(got))
+				}
+
+				return
+			}
+
+			for _, g := range got {
+				if g.Type() == tc.want {
+					return
+				}
+			}
+
+			t.Fatalf("expected a %s mutant, got %s", tc.want, describe(got))
+		})
+	}
+}
+
+// operatorZoo exercises every Go operator gremlins has a mapping for, in both
+// the prefix and the infix spelling wherever Go admits both. It is a whole
+// compilable package so that the mutants generated from it can be handed to
+// the real compiler.
+const operatorZoo = `package zoo
+
+type point struct{ x, y int }
+
+func Address(i int) *int      { return &i }
+func Composite() *point       { return &point{x: 1, y: 2} }
+func Complement(u uint) uint  { return ^u }
+func Negate(i int) int        { return -i }
+func Identity(i int) int      { return +i }
+func Receive(c chan int) int  { return <-c }
+func Negation(b bool) bool    { return !b }
+func And(a, b int) int        { return a & b }
+func Or(a, b int) int         { return a | b }
+func Xor(a, b int) int        { return a ^ b }
+func AndNot(a, b int) int     { return a &^ b }
+func Shl(a int) int           { return a << 1 }
+func Shr(a int) int           { return a >> 1 }
+func Add(a, b int) int        { return a + b }
+func Sub(a, b int) int        { return a - b }
+func Mul(a, b int) int        { return a * b }
+func Quo(a, b int) int        { return a / b }
+func Rem(a, b int) int        { return a % b }
+func Greater(a, b int) bool   { return a > b }
+func Equal(a, b int) bool     { return a == b }
+func Both(a, b bool) bool     { return a && b }
+
+func Assigns(a int) int {
+	a += 1
+	a -= 1
+	a *= 2
+	a /= 2
+	a %= 2
+	a &= 3
+	a |= 3
+	a ^= 3
+	a &^= 3
+	a <<= 1
+	a >>= 1
+	a++
+	a--
+
+	for {
+		if a > 0 {
+			break
+		}
+
+		continue
+	}
+
+	return a
+}
+`
+
+const zooModule = "example.com"
+
+// TestEveryGeneratedMutantCompiles is the gate on the whole mutation table,
+// not just on the two prefix operators this change removes. A mutant the
+// compiler rejects is not evidence about a test suite in either direction: it
+// cannot be detected, so crediting a KILL for it pays the suite for the
+// compiler's work, and recording it NOT VIABLE leaves a package's mutant set
+// padded with entries that mean nothing. So the invariant is that gremlins
+// does not emit one at all, and the only witness that settles it is the real
+// compiler.
+func TestEveryGeneratedMutantCompiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", "module "+zooModule+"\n\ngo 1.25\n")
+	writeFile(t, dir, "zoo.go", operatorZoo)
+
+	viperSet(map[string]any{configuration.UnleashDryRunKey: true})
+	defer viperReset()
+
+	mapFS := fstest.MapFS{"zoo.go": {Data: []byte(operatorZoo)}}
+	mod := gomodule.GoModule{Name: zooModule, Root: ".", CallingDir: "."}
+	mut := engine.New(mod, engine.CodeData{}, newJobDealerStub(t), engine.WithDirFs(mapFS))
+	mutants := mut.Run(context.Background()).Mutants
+
+	// A silent zero here would make every assertion below vacuous.
+	if len(mutants) == 0 {
+		t.Fatal("the operator zoo produced no mutants at all")
+	}
+	if out, err := goBuild(dir); err != nil {
+		t.Fatalf("the unmutated operator zoo does not compile:\n%s", out)
+	}
+
+	for _, m := range mutants {
+		m.SetWorkdir(dir)
+		if err := m.Apply(); err != nil {
+			t.Fatalf("applying the %s mutant at %s: %v", m.Type(), m.Position(), err)
+		}
+		out, buildErr := goBuild(dir)
+		mutated := string(m.MutatedSnippet())
+		if err := m.Rollback(); err != nil {
+			t.Fatalf("rolling back the %s mutant at %s: %v", m.Type(), m.Position(), err)
+		}
+
+		if buildErr != nil {
+			t.Errorf("%s at %s produced a mutant the compiler rejects:\n%s\nmutated source:\n%s",
+				m.Type(), m.Position(), out, mutated)
+		}
+	}
+}
+
+// describe renders a mutant list as the type and position of each entry,
+// which is what a failure here needs to name.
+func describe(mutants []mutator.Mutator) string {
+	described := make([]string, 0, len(mutants))
+	for _, m := range mutants {
+		described = append(described, fmt.Sprintf("%s at %s", m.Type(), m.Position()))
+	}
+
+	return strings.Join(described, ", ")
+}
+
+func goBuild(dir string) (string, error) {
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+
+	return string(out), err
+}

--- a/internal/engine/unary_mutation_test.go
+++ b/internal/engine/unary_mutation_test.go
@@ -18,15 +18,10 @@ package engine_test
 
 import (
 	"context"
-	"fmt"
-	"os/exec"
-	"strings"
 	"testing"
-	"testing/fstest"
 
 	"github.com/go-gremlins/gremlins/internal/configuration"
 	"github.com/go-gremlins/gremlins/internal/engine"
-	"github.com/go-gremlins/gremlins/internal/gomodule"
 	"github.com/go-gremlins/gremlins/internal/mutator"
 )
 
@@ -114,131 +109,4 @@ func TestUnaryOperatorsAreNotMutatedAsBinaryOnes(t *testing.T) {
 			t.Fatalf("expected a %s mutant, got %s", tc.want, describe(got))
 		})
 	}
-}
-
-// operatorZoo exercises every Go operator gremlins has a mapping for, in both
-// the prefix and the infix spelling wherever Go admits both. It is a whole
-// compilable package so that the mutants generated from it can be handed to
-// the real compiler.
-const operatorZoo = `package zoo
-
-type point struct{ x, y int }
-
-func Address(i int) *int      { return &i }
-func Composite() *point       { return &point{x: 1, y: 2} }
-func Complement(u uint) uint  { return ^u }
-func Negate(i int) int        { return -i }
-func Identity(i int) int      { return +i }
-func Receive(c chan int) int  { return <-c }
-func Negation(b bool) bool    { return !b }
-func And(a, b int) int        { return a & b }
-func Or(a, b int) int         { return a | b }
-func Xor(a, b int) int        { return a ^ b }
-func AndNot(a, b int) int     { return a &^ b }
-func Shl(a int) int           { return a << 1 }
-func Shr(a int) int           { return a >> 1 }
-func Add(a, b int) int        { return a + b }
-func Sub(a, b int) int        { return a - b }
-func Mul(a, b int) int        { return a * b }
-func Quo(a, b int) int        { return a / b }
-func Rem(a, b int) int        { return a % b }
-func Greater(a, b int) bool   { return a > b }
-func Equal(a, b int) bool     { return a == b }
-func Both(a, b bool) bool     { return a && b }
-
-func Assigns(a int) int {
-	a += 1
-	a -= 1
-	a *= 2
-	a /= 2
-	a %= 2
-	a &= 3
-	a |= 3
-	a ^= 3
-	a &^= 3
-	a <<= 1
-	a >>= 1
-	a++
-	a--
-
-	for {
-		if a > 0 {
-			break
-		}
-
-		continue
-	}
-
-	return a
-}
-`
-
-const zooModule = "example.com"
-
-// TestEveryGeneratedMutantCompiles is the gate on the whole mutation table,
-// not just on the two prefix operators this change removes. A mutant the
-// compiler rejects is not evidence about a test suite in either direction: it
-// cannot be detected, so crediting a KILL for it pays the suite for the
-// compiler's work, and recording it NOT VIABLE leaves a package's mutant set
-// padded with entries that mean nothing. So the invariant is that gremlins
-// does not emit one at all, and the only witness that settles it is the real
-// compiler.
-func TestEveryGeneratedMutantCompiles(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	writeFile(t, dir, "go.mod", "module "+zooModule+"\n\ngo 1.25\n")
-	writeFile(t, dir, "zoo.go", operatorZoo)
-
-	viperSet(map[string]any{configuration.UnleashDryRunKey: true})
-	defer viperReset()
-
-	mapFS := fstest.MapFS{"zoo.go": {Data: []byte(operatorZoo)}}
-	mod := gomodule.GoModule{Name: zooModule, Root: ".", CallingDir: "."}
-	mut := engine.New(mod, engine.CodeData{}, newJobDealerStub(t), engine.WithDirFs(mapFS))
-	mutants := mut.Run(context.Background()).Mutants
-
-	// A silent zero here would make every assertion below vacuous.
-	if len(mutants) == 0 {
-		t.Fatal("the operator zoo produced no mutants at all")
-	}
-	if out, err := goBuild(dir); err != nil {
-		t.Fatalf("the unmutated operator zoo does not compile:\n%s", out)
-	}
-
-	for _, m := range mutants {
-		m.SetWorkdir(dir)
-		if err := m.Apply(); err != nil {
-			t.Fatalf("applying the %s mutant at %s: %v", m.Type(), m.Position(), err)
-		}
-		out, buildErr := goBuild(dir)
-		mutated := string(m.MutatedSnippet())
-		if err := m.Rollback(); err != nil {
-			t.Fatalf("rolling back the %s mutant at %s: %v", m.Type(), m.Position(), err)
-		}
-
-		if buildErr != nil {
-			t.Errorf("%s at %s produced a mutant the compiler rejects:\n%s\nmutated source:\n%s",
-				m.Type(), m.Position(), out, mutated)
-		}
-	}
-}
-
-// describe renders a mutant list as the type and position of each entry,
-// which is what a failure here needs to name.
-func describe(mutants []mutator.Mutator) string {
-	described := make([]string, 0, len(mutants))
-	for _, m := range mutants {
-		described = append(described, fmt.Sprintf("%s at %s", m.Type(), m.Position()))
-	}
-
-	return strings.Join(described, ", ")
-}
-
-func goBuild(dir string) (string, error) {
-	cmd := exec.Command("go", "build", "./...")
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-
-	return string(out), err
 }

--- a/internal/engine/vet_internal_test.go
+++ b/internal/engine/vet_internal_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// vetZooSource is exactly the shape INVERT_LOGICAL produces from the extremely
+// common `name == constA || name == constB`: a conjunction of equalities
+// against two DISTINCT CONSTANTS, which is what vet's bools analyzer looks for
+// (it ignores the same shape over variables, whose values it cannot compare).
+// `go build` accepts this without a word; `go vet` calls it "suspect and", and
+// `go test` runs that analyzer before it builds anything.
+//
+// It is taken from a real one: cerberus's internal/logql/detected_level.go
+// reads `name == detectedLevelLabel || name == levelLabelAlias`, and its
+// INVERT_LOGICAL mutant was recorded NOT VIABLE on that account.
+const (
+	vetZooSource = `package vetzoo
+
+const (
+	detectedLevelLabel = "detected_level"
+	levelLabelAlias    = "level"
+)
+
+func IsLevelLabel(name string) bool { return name == detectedLevelLabel && name == levelLabelAlias }
+`
+	vetZooTest = `package vetzoo
+
+import "testing"
+
+func TestIsLevelLabel(t *testing.T) {
+	if IsLevelLabel("detected_level") {
+		t.Fatal("IsLevelLabel reported true for a name that cannot equal both constants")
+	}
+}
+`
+	// vetSuspectAnd is what `go test` prints when it refuses to build this.
+	vetSuspectAnd = "suspect and"
+
+	// vetZooRunBound is only there because getTestArgs requires a run bound;
+	// nothing in this test is timing-sensitive.
+	vetZooRunBound = time.Minute
+
+	// noTestCache is added to both invocations below. Go's test result cache
+	// is keyed on the test BINARY and the arguments handed to the binary, and
+	// -vet is neither -- it is a build-time flag. So the two invocations below
+	// share a cache entry, and without this the second one reuses the first
+	// one's verdict and the comparison measures the cache rather than vet.
+	noTestCache = "-count=1"
+)
+
+// uncached returns args with the test result cache disabled, keeping `test`
+// first because `go` reads the subcommand from there.
+func uncached(args []string) []string {
+	return slices.Insert(slices.Clone(args), 1, noTestCache)
+}
+
+// TestMutantsAreRunWithVetDisabled pins the decision that a mutant is
+// adjudicated by the compiler and the test suite, and by nothing else.
+//
+// `go test` runs a subset of `go vet` before it builds anything, and reports a
+// finding as `FAIL pkg [build failed]` — indistinguishable, from the outside,
+// from source that does not compile. One of those analyzers, bools, rejects
+// precisely the output of INVERT_LOGICAL on an equality disjunction, so with
+// vet left on a whole class of mutants could never reach a test binary at all.
+//
+// Every one of them is legal Go and a real change of behaviour, so the answer
+// is not to stop generating them — that would drop from the corpus mutants the
+// suite ought to be asked about. It is to stop asking a style analyzer whether
+// a mutant may be adjudicated.
+//
+// Both halves are asserted behaviourally, because only the pair is evidence:
+// the first shows the mutant now builds and runs, and the second shows that it
+// is `-vet=off` that makes it, rather than the shape having stopped tripping
+// vet at some toolchain version.
+func TestMutantsAreRunWithVetDisabled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"go.mod":      "module example.com/vetzoo\n\ngo 1.25\n",
+		"zoo.go":      vetZooSource,
+		"zoo_test.go": vetZooTest,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+
+	sut := &mutantExecutor{testExecutionTime: vetZooRunBound}
+	args := sut.getTestArgs("./...")
+	if !slices.Contains(args, vetOff) {
+		t.Fatalf("gremlins does not pass %s to go test; args were %v", vetOff, args)
+	}
+
+	asGremlinsRuns := uncached(args)
+	out, err := goTest(t, dir, asGremlinsRuns)
+	if err != nil {
+		t.Errorf("go test %v rejected a mutant that compiles:\n%s", asGremlinsRuns, out)
+	}
+
+	withVet := uncached(slices.DeleteFunc(slices.Clone(args), func(a string) bool { return a == vetOff }))
+	out, err = goTest(t, dir, withVet)
+	if err == nil {
+		t.Fatalf("go test %v accepted the suspect conjunction, so %s is no longer load-bearing "+
+			"and this test proves nothing:\n%s", withVet, vetOff, out)
+	}
+	if !strings.Contains(out, vetSuspectAnd) {
+		t.Errorf("go test %v failed for a reason other than %q, so the comparison above is not "+
+			"measuring vet:\n%s", withVet, vetSuspectAnd, out)
+	}
+}
+
+func goTest(t *testing.T, dir string, args []string) (string, error) {
+	t.Helper()
+
+	//nolint:gosec // args come from getTestArgs and this file's own constants
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+
+	return string(out), err
+}

--- a/internal/engine/viability.go
+++ b/internal/engine/viability.go
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/go-gremlins/gremlins/internal/log"
+)
+
+// Viability answers whether rewriting one token leaves the source it sits in
+// legal Go.
+//
+// Gremlins rewrites a token in the AST and writes the file back out. The token
+// table says which rewrites are meaningful for a token READ IN ISOLATION, and
+// that is all a table can say: whether the result is a program at all depends
+// on the types of the operands, on the constant values around it, and on what
+// statements the enclosing function admits. None of that is in the token.
+//
+// A mutant the compiler rejects is not evidence about a test suite in either
+// direction. It cannot be detected, so crediting a kill for it pays the suite
+// for the compiler's work; recording it NOT VIABLE leaves the package's mutant
+// set padded with entries that describe the compiler rather than the tests. So
+// it is not generated, and the only oracle precise enough to decide that is a
+// type-checker.
+type Viability interface {
+	// Viable reports whether replacing the token at pos with mutated leaves
+	// the package that token belongs to type-correct.
+	//
+	// It reports TRUE whenever it cannot answer. A checker that cannot load a
+	// package must fall back to generating the mutant and letting the compiler
+	// adjudicate it, exactly as gremlins did before this existed: silently
+	// dropping a mutant nobody proved illegal would shrink a package's mutant
+	// set on the strength of a failure to look.
+	Viable(pos token.Position, mutated token.Token) bool
+}
+
+// TypeViability answers Viable by type-checking the package the token belongs
+// to, with the token rewritten in place.
+//
+// The unit is the PACKAGE, not the expression, because the error a mutation
+// causes does not have to appear where the mutation is. `const week = 7 * 24 *
+// time.Hour` rewritten to `7 / 24 * time.Hour` is a legal constant expression
+// on its own line; it is the `d / week` three lines down that becomes a
+// division by zero. Only a checker that sees the whole package sees that.
+//
+// The cost is one type-check per candidate mutant, which is the cheap end of
+// what gremlins already spends: a mutant that IS generated costs a full
+// recompile, link and test run, so a check that removes one pays for itself
+// many times over. Measured on cerberus's internal/promql (101 files, ~93k
+// lines), one re-check of the whole package takes ~100ms against a ~10s
+// per-mutant cycle, and generation runs on its own goroutine behind the
+// executor pool.
+type TypeViability struct {
+	// root is the directory the engine's fs.FS is rooted at, which is what
+	// the relative filenames in a token.Position are relative to.
+	root string
+	// tags is the build-tag expression gremlins was given, so that the
+	// package is loaded in the same configuration its tests run in.
+	tags string
+
+	// mu guards the caches below and the in-place token rewrites the checks
+	// perform on the cached ASTs. Generation is single-goroutine today; the
+	// lock is what keeps that from being load-bearing.
+	mu       sync.Mutex
+	packages map[string]*viabilityPackage
+	// reported is the set of files already named in an "unchecked" log line,
+	// so a file that cannot be checked says so once instead of once per token.
+	reported map[string]bool
+}
+
+// NewTypeViability builds a Viability rooted at dir, loading packages with the
+// given build tags. Nothing is loaded until the first Viable call, and then
+// only the package of the file being asked about.
+func NewTypeViability(dir, tags string) *TypeViability {
+	// Absolute, because the positions this is compared against come from
+	// go/packages and `go list` reports absolute paths, while gremlins'
+	// GoModule.Root is relative whenever the scope was given as a relative
+	// path -- which is how every documented invocation gives it.
+	root, err := filepath.Abs(dir)
+	if err != nil {
+		root = dir
+	}
+
+	return &TypeViability{
+		root:     root,
+		tags:     tags,
+		packages: make(map[string]*viabilityPackage),
+		reported: make(map[string]bool),
+	}
+}
+
+// viabilityPackage is one loaded, type-checkable package: its files parsed
+// into a single FileSet, an importer that resolves its dependencies from the
+// types packages.Load already built, and an index from source position to the
+// token at that position so a mutation can be applied in place.
+//
+// A nil *viabilityPackage in the cache means "this directory cannot be
+// checked", which is a permanent answer for the run and always yields viable.
+type viabilityPackage struct {
+	path     string
+	fset     *token.FileSet
+	files    []*ast.File
+	importer types.Importer
+	sizes    types.Sizes
+	tokens   map[tokenSite]*token.Token
+	// sources is the set of files this package is built from, so that a file
+	// the package does NOT contain -- one the build tags excluded, say -- is
+	// reported as unchecked rather than passed off as having no illegal
+	// mutants.
+	sources map[string]bool
+}
+
+// buildTagsFlag is how both `go list` (through go/packages, below) and
+// `go test` (in getTestArgs) are told which build tags gremlins was given, so
+// the package this checks is the one whose tests will run.
+const buildTagsFlag = "-tags"
+
+// tokenSite identifies a mutable token by where it is written, which is the
+// only handle the engine and the checker share: they parse the same bytes into
+// two independent ASTs, and a token.Position is stable across both.
+type tokenSite struct {
+	file   string
+	line   int
+	column int
+}
+
+// Viable implements Viability.
+func (v *TypeViability) Viable(pos token.Position, mutated token.Token) bool {
+	file := pos.Filename
+	if !filepath.IsAbs(file) {
+		file = filepath.Join(v.root, file)
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	pkg := v.packageFor(file)
+	if pkg == nil {
+		return true
+	}
+	tok, ok := pkg.tokens[tokenSite{file: file, line: pos.Line, column: pos.Column}]
+	if !ok {
+		// The engine and the checker parse the same bytes, so every mutable
+		// token the engine finds in a file the package contains is indexed
+		// here. A miss therefore means the file is not in the package, or
+		// that the two disagree about where its tokens are -- and either way
+		// this stopped being an oracle for that file, which has to be said
+		// out loud rather than answered "viable".
+		reason := "the token is not where the loaded package has one"
+		if !pkg.sources[file] {
+			reason = "the file is not one this package is built from, so no build of it was checked"
+		}
+		v.unchecked(file, reason)
+
+		return true
+	}
+
+	original := *tok
+	*tok = mutated
+	defer func() { *tok = original }()
+
+	return pkg.typeChecks()
+}
+
+// packageFor returns the loaded package owning file, loading it on first ask.
+// It returns nil — cached, so the cost is paid once — when the file's package
+// cannot be used as an oracle.
+func (v *TypeViability) packageFor(file string) *viabilityPackage {
+	dir := filepath.Dir(file)
+	if pkg, ok := v.packages[dir]; ok {
+		return pkg
+	}
+	pkg := v.load(dir, file)
+	v.packages[dir] = pkg
+
+	return pkg
+}
+
+func (v *TypeViability) load(dir, file string) *viabilityPackage {
+	// A file the engine can see through its fs.FS but that is not on disk is
+	// a fixture in a testing/fstest.MapFS, and `go list` has nothing to load.
+	// Checked before the load so the common case costs a stat, not a `go
+	// list` that will fail. It is also the only "unchecked" case that is not
+	// logged: there is no package here to have been an oracle.
+	if _, err := os.Stat(file); err != nil {
+		return nil
+	}
+
+	fset := token.NewFileSet()
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedSyntax,
+		Dir:  dir,
+		Fset: fset,
+	}
+	if v.tags != "" {
+		cfg.BuildFlags = []string{buildTagsFlag, v.tags}
+	}
+
+	loaded, err := packages.Load(cfg, ".")
+	if err != nil {
+		v.unchecked(dir, err.Error())
+
+		return nil
+	}
+	if len(loaded) != 1 {
+		v.unchecked(dir, "the directory does not resolve to exactly one package")
+
+		return nil
+	}
+
+	pkg := &viabilityPackage{
+		path:     loaded[0].PkgPath,
+		fset:     fset,
+		files:    loaded[0].Syntax,
+		importer: dependencyImporter(loaded[0]),
+		sizes:    types.SizesFor("gc", runtime.GOARCH),
+		tokens:   make(map[tokenSite]*token.Token),
+		sources:  make(map[string]bool, len(loaded[0].CompiledGoFiles)),
+	}
+	for _, f := range loaded[0].CompiledGoFiles {
+		pkg.sources[f] = true
+	}
+	for _, f := range pkg.files {
+		indexTokens(fset, f, pkg.tokens)
+	}
+
+	// The baseline. Everything this checker rejects, it rejects because the
+	// mutation is the only thing that changed, so it may only be trusted over
+	// a package that type-checks clean to begin with. This is also what
+	// catches a misconfigured load — the wrong build tags, an unresolved
+	// dependency, a language version this go/types cannot express — without
+	// having to enumerate those failures: they all land here, and they all
+	// disable the checker for that package rather than suppressing mutants.
+	if !pkg.typeChecks() {
+		v.unchecked(dir, "the unmutated package does not type-check")
+
+		return nil
+	}
+
+	return pkg
+}
+
+// unchecked reports source whose mutants will be adjudicated by the compiler
+// at run time instead. It is logged rather than silent because the difference
+// between "no mutant here is illegal" and "nobody looked" is exactly what a
+// NOT VIABLE count is read as evidence of -- and because a checker that
+// quietly stops matching anything looks, from the outside, precisely like one
+// that has nothing to reject.
+func (v *TypeViability) unchecked(path, reason string) {
+	if v.reported[path] {
+		return
+	}
+	v.reported[path] = true
+	log.Infof("not type-checking mutants in %s (%s); the compiler adjudicates them instead\n", path, reason)
+}
+
+// typeChecks reports whether the package's files, as they currently stand,
+// type-check without a single error.
+func (p *viabilityPackage) typeChecks() bool {
+	clean := true
+	conf := types.Config{
+		Importer: p.importer,
+		Sizes:    p.sizes,
+		// Collecting rather than aborting: go/types stops at the first error
+		// when Error is nil, and a checker that stops early reports the same
+		// verdict either way. What matters is that an error handler exists so
+		// a hard failure does not panic out of generation.
+		Error: func(error) { clean = false },
+		// GoVersion is deliberately left empty, which imposes no language
+		// version at all. Guessing one wrong would reject legal source and
+		// suppress honest mutants; imposing none can only ACCEPT source the
+		// real compiler would reject, which leaves the mutant to be
+		// adjudicated exactly as it is today.
+	}
+	_, _ = conf.Check(p.path, p.fset, p.files, nil)
+
+	return clean
+}
+
+// indexTokens records every token the engine can mutate in this file, keyed by
+// where it is written. It reads nodes through NewTokenNode so that the set of
+// mutable tokens has one definition: a node shape the engine learns to mutate
+// is a node shape this checker indexes, with no second list to keep in step.
+func indexTokens(fset *token.FileSet, file *ast.File, out map[tokenSite]*token.Token) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		node, ok := NewTokenNode(n)
+		if !ok {
+			return true
+		}
+		pos := fset.Position(node.TokPos)
+		out[tokenSite{file: pos.Filename, line: pos.Line, column: pos.Column}] = node.tok
+
+		return true
+	})
+}
+
+// dependencyImporter resolves imports from the type information packages.Load
+// already built for the dependency graph, so a re-check costs only the
+// package's own files.
+func dependencyImporter(root *packages.Package) types.Importer {
+	resolved := make(mapImporter)
+	var walk func(p *packages.Package)
+	walk = func(p *packages.Package) {
+		if p == nil || p.Types == nil {
+			return
+		}
+		if _, seen := resolved[p.PkgPath]; seen {
+			return
+		}
+		resolved[p.PkgPath] = p.Types
+		for _, dep := range p.Imports {
+			walk(dep)
+		}
+	}
+	walk(root)
+
+	return resolved
+}
+
+type mapImporter map[string]*types.Package
+
+// Import implements types.Importer.
+func (m mapImporter) Import(path string) (*types.Package, error) {
+	if pkg, ok := m[path]; ok {
+		return pkg, nil
+	}
+
+	// An unresolvable import makes the baseline check fail, which disables the
+	// checker for the package. That is the intended outcome: a package whose
+	// dependencies are not all present cannot decide anything about a mutant.
+	return nil, os.ErrNotExist
+}

--- a/internal/engine/viability_test.go
+++ b/internal/engine/viability_test.go
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-gremlins/gremlins/internal/engine"
+	"github.com/go-gremlins/gremlins/internal/gomodule"
+	"github.com/go-gremlins/gremlins/internal/mutator"
+
+	"github.com/go-gremlins/gremlins/internal/configuration"
+)
+
+// operatorZoo exercises every Go operator gremlins has a mapping for, in both
+// the prefix and the infix spelling wherever Go admits both, and then every
+// shape in which a mapped mutation produces source that is not a program.
+//
+// It is a whole compilable package so that the mutants generated from it can
+// be handed to the real compiler. The `// illegal:` and `// legal:` markers on
+// its lines are read back by the tests below — see zooSites — so that the
+// expected verdicts live next to the code that produces them rather than in a
+// separate table of line numbers nobody can check by eye.
+const operatorZoo = `package zoo
+
+type point struct{ x, y int }
+
+func Address(i int) *int      { return &i }
+func Composite() *point       { return &point{x: 1, y: 2} }
+func Complement(u uint) uint  { return ^u }
+func Negate(i int) int        { return -i }
+func Identity(i int) int      { return +i }
+func Receive(c chan int) int  { return <-c }
+func Negation(b bool) bool    { return !b }
+func And(a, b int) int        { return a & b }
+func Or(a, b int) int         { return a | b }
+func Xor(a, b int) int        { return a ^ b }
+func AndNot(a, b int) int     { return a &^ b }
+func Shl(a int) int           { return a << 1 }
+func Shr(a int) int           { return a >> 1 }
+func Add(a, b int) int        { return a + b }
+func Sub(a, b int) int        { return a - b }
+func Mul(a, b int) int        { return a * b }
+func Quo(a, b int) int        { return a / b }
+func Rem(a, b int) int        { return a % b }
+func Greater(a, b int) bool   { return a > b }
+func Equal(a, b int) bool     { return a == b }
+func Both(a, b bool) bool     { return a && b }  // legal: INVERT_LOGICAL
+
+// Go defines + on strings and defines nothing else on them, so ARITHMETIC_BASE
+// and INVERT_ASSIGNMENTS both have an entry for a token whose operands forbid
+// the mutation. Nothing about the token says so; only the operand types do.
+func Join(a, b string) string     { return a + "-" + b } // illegal: ARITHMETIC_BASE
+func AppendTo(a, b string) string { a += b; return a }   // illegal: INVERT_ASSIGNMENTS  legal: REMOVE_SELF_ASSIGNMENTS
+
+// The mutated expression is legal in isolation and wrong only where its value
+// is used: 7 * 24 rewritten to 7 / 24 is the untyped constant 0, and it is the
+// division three lines down that the compiler rejects. Anything narrower than
+// a whole-package check cannot see this.
+const hoursPerWeek = 7 * 24 // illegal: ARITHMETIC_BASE
+
+func Weeks(hours int) int { return hours / hoursPerWeek } // legal: ARITHMETIC_BASE
+
+// A ` + "`for`" + ` with no reachable break is a terminating statement, so this
+// function needs no return after it. INVERT_LOOPCTRL turns the continue into a
+// break, the loop stops terminating, and the function is missing a return.
+func FirstPositive(xs []int) int {
+	i := 0
+	for {
+		if xs[i] <= 0 { // legal: CONDITIONALS_BOUNDARY
+			i++ // legal: INCREMENT_DECREMENT
+			continue // illegal: INVERT_LOOPCTRL
+		}
+
+		return xs[i]
+	}
+}
+
+// The same mutation the other way round: a break in a switch that no loop
+// encloses has a meaning, and continue has none there.
+func Classify(a int) string {
+	switch a {
+	case 1:
+		break // illegal: INVERT_LOOPCTRL
+	}
+
+	return "one"
+}
+
+func Assigns(a int) int {
+	a += 1
+	a -= 1
+	a *= 2
+	a /= 2
+	a %= 2
+	a &= 3
+	a |= 3
+	a ^= 3
+	a &^= 3
+	a <<= 1
+	a >>= 1
+	a++
+	a--
+
+	for {
+		if a > 0 {
+			break
+		}
+
+		continue
+	}
+
+	return a
+}
+`
+
+const zooModule = "example.com"
+
+// zooSite is one mutation the zoo's markers make a claim about: the line it
+// sits on and the mutator.Type that reaches it.
+type zooSite struct {
+	line  int
+	mType string
+}
+
+func (s zooSite) String() string {
+	return fmt.Sprintf("%s at line %d", s.mType, s.line)
+}
+
+// zooSites reads the `// <marker>:` annotations out of operatorZoo. A marker
+// names one or more mutator types, all of which are claimed to be illegal (or
+// legal) at that line.
+func zooSites(marker string) map[zooSite]bool {
+	sites := make(map[zooSite]bool)
+	for i, line := range strings.Split(operatorZoo, "\n") {
+		_, comment, found := strings.Cut(line, "// ")
+		if !found {
+			continue
+		}
+		for _, claim := range strings.Split(comment, "  ") {
+			name, types, ok := strings.Cut(claim, ": ")
+			if !ok || name != marker {
+				continue
+			}
+			for _, mType := range strings.Fields(types) {
+				// operatorZoo is embedded in a Go string that starts on the
+				// line after the backquote, so the zoo's own line 1 is this
+				// slice's index 0.
+				sites[zooSite{line: i + 1, mType: mType}] = true
+			}
+		}
+	}
+
+	return sites
+}
+
+// generateZoo writes the zoo into a fresh module and runs the engine over it,
+// returning the mutants and the directory they can be applied to.
+//
+// The engine reads the directory itself rather than a testing/fstest.MapFS,
+// because that is the only configuration in which the default Viability has a
+// package to load: the checker's whole subject is source that a compiler could
+// be asked about, and a map in memory is not that.
+func generateZoo(t *testing.T, opts ...engine.Option) ([]mutator.Mutator, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", "module "+zooModule+"\n\ngo 1.25\n")
+	writeFile(t, dir, "zoo.go", operatorZoo)
+
+	viperSet(map[string]any{configuration.UnleashDryRunKey: true})
+	defer viperReset()
+
+	mod := gomodule.GoModule{Name: zooModule, Root: dir, CallingDir: "."}
+	mut := engine.New(mod, engine.CodeData{}, newJobDealerStub(t), opts...)
+	mutants := mut.Run(context.Background()).Mutants
+
+	// A silent zero here would make every assertion built on it vacuous.
+	if len(mutants) == 0 {
+		t.Fatal("the operator zoo produced no mutants at all")
+	}
+	if out, err := goBuild(dir); err != nil {
+		t.Fatalf("the unmutated operator zoo does not compile:\n%s", out)
+	}
+
+	return mutants, dir
+}
+
+// rejectedByCompiler applies each mutant in turn, hands the result to the real
+// compiler, and returns the sites the compiler refused along with what it said
+// about each.
+func rejectedByCompiler(t *testing.T, mutants []mutator.Mutator, dir string) (map[zooSite]bool, []string) {
+	t.Helper()
+
+	rejected := make(map[zooSite]bool)
+	var diagnostics []string
+	for _, m := range mutants {
+		m.SetWorkdir(dir)
+		if err := m.Apply(); err != nil {
+			t.Fatalf("applying the %s mutant at %s: %v", m.Type(), m.Position(), err)
+		}
+		out, buildErr := goBuild(dir)
+		mutated := string(m.MutatedSnippet())
+		if err := m.Rollback(); err != nil {
+			t.Fatalf("rolling back the %s mutant at %s: %v", m.Type(), m.Position(), err)
+		}
+		if buildErr == nil {
+			continue
+		}
+		rejected[zooSite{line: m.Position().Line, mType: m.Type().String()}] = true
+		diagnostics = append(diagnostics,
+			fmt.Sprintf("%s at %s:\n%s\nmutated source:\n%s", m.Type(), m.Position(), out, mutated))
+	}
+
+	return rejected, diagnostics
+}
+
+// TestEveryGeneratedMutantCompiles is the gate on the whole mutation table.
+//
+// A mutant the compiler rejects is not evidence about a test suite in either
+// direction: it cannot be detected, so crediting a KILL for it pays the suite
+// for the compiler's work, and recording it NOT VIABLE leaves a package's
+// mutant set padded with entries that mean nothing. So the invariant is that
+// gremlins does not emit one at all, and the only witness that settles it is
+// the real compiler.
+func TestEveryGeneratedMutantCompiles(t *testing.T) {
+	t.Parallel()
+
+	mutants, dir := generateZoo(t)
+	_, diagnostics := rejectedByCompiler(t, mutants, dir)
+	for _, d := range diagnostics {
+		t.Errorf("a generated mutant the compiler rejects:\n%s", d)
+	}
+}
+
+// TestTheViabilityCheckIsWhatKeepsTheZooCompiling is the break-proof for the
+// gate above: it runs the identical generation with the Viability removed and
+// requires the compiler to reject EXACTLY the sites operatorZoo marks illegal.
+//
+// Without it TestEveryGeneratedMutantCompiles is a test that cannot fail — it
+// would pass just as well against a fixture that never exercised the shapes,
+// or against a checker that had been quietly disabled. Requiring the exact set
+// pins the guard from both sides: a shape the fixture claims to cover but does
+// not is a missing rejection here, and a mutation the checker suppresses
+// although the compiler accepts it is an extra one.
+func TestTheViabilityCheckIsWhatKeepsTheZooCompiling(t *testing.T) {
+	t.Parallel()
+
+	mutants, dir := generateZoo(t, engine.WithViability(nil))
+	rejected, _ := rejectedByCompiler(t, mutants, dir)
+
+	want := zooSites("illegal")
+	if len(want) == 0 {
+		t.Fatal("operatorZoo marks no site illegal, so this test asserts nothing")
+	}
+	for site := range want {
+		if !rejected[site] {
+			t.Errorf("operatorZoo marks %s illegal, but the compiler accepted it with the "+
+				"viability check off: the fixture no longer exercises that shape, so the gate "+
+				"passes without evidence", site)
+		}
+	}
+	for site := range rejected {
+		if !want[site] {
+			t.Errorf("the compiler rejected %s, which operatorZoo does not mark illegal: either "+
+				"the fixture gained a shape nobody accounted for, or the mutation table did", site)
+		}
+	}
+}
+
+// TestViabilityKeepsTheLegalMutationsAtTheSameSites is the guard in the other
+// direction. The check removes mutants, and removing mutants is exactly how a
+// mutation score can be inflated, so it has to be shown to remove only what
+// the compiler would have rejected anyway. Every site the zoo marks legal
+// carries a mutation whose token sits on the same line as an illegal one, or
+// is the same token under a different mutator; all of them must survive.
+func TestViabilityKeepsTheLegalMutationsAtTheSameSites(t *testing.T) {
+	t.Parallel()
+
+	mutants, _ := generateZoo(t)
+
+	generated := make(map[zooSite]bool)
+	for _, m := range mutants {
+		generated[zooSite{line: m.Position().Line, mType: m.Type().String()}] = true
+	}
+
+	want := zooSites("legal")
+	if len(want) == 0 {
+		t.Fatal("operatorZoo marks no site legal, so this test asserts nothing")
+	}
+	for site := range want {
+		if !generated[site] {
+			t.Errorf("the viability check suppressed %s, which the compiler accepts: it is "+
+				"removing honest mutants, which shrinks the denominator a mutation score is "+
+				"measured against.\ngenerated: %s", site, describeSites(generated))
+		}
+	}
+}
+
+// describe renders a mutant list as the type and position of each entry,
+// which is what a failure here needs to name.
+func describe(mutants []mutator.Mutator) string {
+	described := make([]string, 0, len(mutants))
+	for _, m := range mutants {
+		described = append(described, fmt.Sprintf("%s at %s", m.Type(), m.Position()))
+	}
+
+	return strings.Join(described, ", ")
+}
+
+func describeSites(sites map[zooSite]bool) string {
+	described := make([]string, 0, len(sites))
+	for site := range sites {
+		described = append(described, site.String())
+	}
+	sort.Strings(described)
+
+	return strings.Join(described, ", ")
+}
+
+func goBuild(dir string) (string, error) {
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+
+	return string(out), err
+}

--- a/internal/engine/workdir/workdir.go
+++ b/internal/engine/workdir/workdir.go
@@ -160,11 +160,14 @@ func doCopy(srcPath, dstPath string, fileMode fs.FileMode) error {
 	if err != nil {
 		return err
 	}
+	defer s.Close()
+
 	//nolint:gosec // dstPath is internally controlled, not user input
 	d, err := os.OpenFile(dstPath, os.O_CREATE|os.O_RDWR, fileMode)
 	if err != nil {
 		return err
 	}
+	defer d.Close()
 
 	if _, err = io.Copy(d, s); err != nil {
 		return err

--- a/internal/mutator/mutator.go
+++ b/internal/mutator/mutator.go
@@ -29,6 +29,21 @@ import "go/token"
 //     means the test suite is not effective in catching it.
 //   - Killed means that the TokenMutant has been tested and the tests failed, which
 //     means they are effective in covering this regression.
+//   - TimedOut means that the deadline wrapping the WHOLE `go test` child —
+//     resolve, compile, link, then run — expired. Which of those phases consumed
+//     it is not known, so the mutant is unadjudicated: a compile that hung
+//     reaches this status identically to a run that did.
+//   - RunTimedOut means that the test BINARY's own -timeout watchdog fired and
+//     said so in its output. That is a positive observation about the mutant
+//     rather than about the machine: a test binary existed, the suite started,
+//     and it did not finish inside a bound the Go toolchain starts when the
+//     binary starts, so compilation cannot have consumed it.
+//
+// The two timeout statuses are kept apart because they carry different
+// evidence, and a consumer that scores them alike scores a slow compiler and a
+// non-terminating mutant identically. gremlins takes no position on which of
+// them is a detection: neither appears in test_efficacy, exactly as before. The
+// distinction is recorded so that a consumer can take one.
 type Status int
 
 // Currently supported MutantStatus.
@@ -40,7 +55,21 @@ const (
 	Killed
 	NotViable
 	TimedOut
+	RunTimedOut
 )
+
+// Statuses allows to iterate over Status. Kept next to the constants so a new
+// status cannot be added without the readers that enumerate them seeing it.
+var Statuses = []Status{
+	NotCovered,
+	Runnable,
+	Skipped,
+	Lived,
+	Killed,
+	NotViable,
+	TimedOut,
+	RunTimedOut,
+}
 
 // ParseShutdownStatus maps the CLI/config value for "what status to assign
 // to mutants that were still in-flight when the runner cancelled the run"
@@ -52,6 +81,11 @@ const (
 // "not-run" maps to NotCovered — the closest existing semantic for "we
 // never got a chance to run this mutant", and avoids inventing a new
 // Status value that would break downstream JSON consumers.
+//
+// "timed-out" maps to TimedOut and deliberately not to RunTimedOut. A mutant
+// the runner cancelled was never adjudicated by anything, which is precisely
+// what TimedOut means; RunTimedOut asserts that a test binary reported the
+// overrun itself, and no shutdown can produce that evidence.
 func ParseShutdownStatus(s string) (Status, bool) {
 	switch s {
 	case "not-run", "notrun", "":
@@ -80,6 +114,8 @@ func (ms Status) String() string {
 		return "NOT VIABLE"
 	case TimedOut:
 		return "TIMED OUT"
+	case RunTimedOut:
+		return "RUN TIMED OUT"
 	default:
 		panic("this should not happen")
 	}

--- a/internal/mutator/mutator.go
+++ b/internal/mutator/mutator.go
@@ -42,6 +42,28 @@ const (
 	TimedOut
 )
 
+// ParseShutdownStatus maps the CLI/config value for "what status to assign
+// to mutants that were still in-flight when the runner cancelled the run"
+// to a concrete Status. The returned bool is false for unrecognised inputs.
+//
+// Accepted forms (case-insensitive): "not-run" (alias "notrun"),
+// "timed-out" (aliases "timedout", "timeout"), "lived".
+//
+// "not-run" maps to NotCovered — the closest existing semantic for "we
+// never got a chance to run this mutant", and avoids inventing a new
+// Status value that would break downstream JSON consumers.
+func ParseShutdownStatus(s string) (Status, bool) {
+	switch s {
+	case "not-run", "notrun", "":
+		return NotCovered, true
+	case "timed-out", "timedout", "timeout":
+		return TimedOut, true
+	case "lived":
+		return Lived, true
+	}
+	return 0, false
+}
+
 func (ms Status) String() string {
 	switch ms {
 	case NotCovered:

--- a/internal/mutator/mutator_test.go
+++ b/internal/mutator/mutator_test.go
@@ -60,6 +60,11 @@ func TestStatusString(t *testing.T) {
 			expected:       "TIMED OUT",
 			mutationStatus: mutator.TimedOut,
 		},
+		{
+			name:           "RunTimedOut",
+			expected:       "RUN TIMED OUT",
+			mutationStatus: mutator.RunTimedOut,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -84,6 +89,10 @@ func TestParseShutdownStatus(t *testing.T) {
 		{in: "timedout", want: mutator.TimedOut, wantOK: true},
 		{in: "timeout", want: mutator.TimedOut, wantOK: true},
 		{in: "lived", want: mutator.Lived, wantOK: true},
+		// Deliberately absent: nothing maps to RunTimedOut. A mutant the runner
+		// cancelled was adjudicated by nothing, and RunTimedOut asserts that a
+		// test binary reported the overrun itself.
+		{in: "run-timed-out", wantOK: false},
 		{in: "garbage", wantOK: false},
 		{in: "KILLED", wantOK: false},
 	}

--- a/internal/mutator/mutator_test.go
+++ b/internal/mutator/mutator_test.go
@@ -71,6 +71,36 @@ func TestStatusString(t *testing.T) {
 	}
 }
 
+func TestParseShutdownStatus(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   mutator.Status
+		wantOK bool
+	}{
+		{in: "not-run", want: mutator.NotCovered, wantOK: true},
+		{in: "notrun", want: mutator.NotCovered, wantOK: true},
+		{in: "", want: mutator.NotCovered, wantOK: true},
+		{in: "timed-out", want: mutator.TimedOut, wantOK: true},
+		{in: "timedout", want: mutator.TimedOut, wantOK: true},
+		{in: "timeout", want: mutator.TimedOut, wantOK: true},
+		{in: "lived", want: mutator.Lived, wantOK: true},
+		{in: "garbage", wantOK: false},
+		{in: "KILLED", wantOK: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			got, ok := mutator.ParseShutdownStatus(tc.in)
+			if ok != tc.wantOK {
+				t.Fatalf("ok: want %v, got %v", tc.wantOK, ok)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("status: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestTypeString(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/internal/report/logger.go
+++ b/internal/report/logger.go
@@ -60,7 +60,8 @@ func (l MutantLogger) Mutant(m mutator.Mutator) {
 }
 
 // ParseFilter parses a status filter string into a Filter map.
-// Valid characters are 'lctkvsr' representing different mutation statuses.
+// Valid characters are 'lctkvsr' representing different mutation statuses;
+// 't' selects both TimedOut and RunTimedOut.
 func ParseFilter(s string) (Filter, error) {
 	if s == "" {
 		return nil, nil
@@ -75,7 +76,12 @@ func ParseFilter(s string) (Filter, error) {
 		case 'c':
 			result[mutator.NotCovered] = struct{}{}
 		case 't':
+			// Both timeout kinds. A reader asking to see timed-out mutants
+			// wants the ones that overran their run as much as the ones the
+			// backstop claimed; the two are told apart by the status printed on
+			// each line, not by having to ask for them separately.
 			result[mutator.TimedOut] = struct{}{}
+			result[mutator.RunTimedOut] = struct{}{}
 		case 'k':
 			result[mutator.Killed] = struct{}{}
 		case 'v':

--- a/internal/report/logger_test.go
+++ b/internal/report/logger_test.go
@@ -29,12 +29,16 @@ func Test_parseFilter(t *testing.T) {
 			},
 		},
 		{
+			// 't' selects BOTH timeout kinds: a reader asking to see timed-out
+			// mutants wants the ones whose run overran as much as the ones the
+			// compile+run backstop claimed.
 			filter: "tkvs",
 			want: report.Filter{
-				mutator.TimedOut:  struct{}{},
-				mutator.Killed:    struct{}{},
-				mutator.NotViable: struct{}{},
-				mutator.Skipped:   struct{}{},
+				mutator.TimedOut:    struct{}{},
+				mutator.RunTimedOut: struct{}{},
+				mutator.Killed:      struct{}{},
+				mutator.NotViable:   struct{}{},
+				mutator.Skipped:     struct{}{},
 			},
 		},
 		{
@@ -151,9 +155,9 @@ func TestLogger(t *testing.T) {
 	got := out.String()
 
 	want := "output-statuses filter not applied: " + report.ErrInvalidFilter.Error() + "\n" +
-		" NOT COVERED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"      KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		"   NOT COVERED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"        KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"         LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
 
 	if !cmp.Equal(got, want) {
 		t.Error(cmp.Diff(got, want))
@@ -207,7 +211,7 @@ func TestLoggerOutputStatusesAndDiffStatusesTogether(t *testing.T) {
 		})
 
 		got := out.String()
-		statusLine := "      KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		statusLine := "        KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
 		if !strings.HasPrefix(got, statusLine) {
 			t.Errorf("expected status line prefix, got: %q", got)
 		}
@@ -225,7 +229,7 @@ func TestLoggerOutputDiffStatuses(t *testing.T) {
 		originSnippet:  []byte("x > y\n"),
 		mutatedSnippet: []byte("x >= y\n"),
 	}
-	statusLine := "       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+	statusLine := "         LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
 
 	t.Run("prints diff when status matches output-diff-statuses", func(t *testing.T) {
 		out := &bytes.Buffer{}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -56,13 +56,14 @@ type reportStatus struct {
 	elapsed *durafmt.Durafmt
 	module  string
 
-	killed     int
-	lived      int
-	timedOut   int
-	notCovered int
-	skipped    int
-	notViable  int
-	runnable   int
+	killed      int
+	lived       int
+	timedOut    int
+	runTimedOut int
+	notCovered  int
+	skipped     int
+	notViable   int
+	runnable    int
 
 	mutatorStatistics internal.MutatorType
 
@@ -116,6 +117,8 @@ func reportMutationStatus(m mutator.Mutator, rep *reportStatus) {
 		rep.skipped++
 	case mutator.TimedOut:
 		rep.timedOut++
+	case mutator.RunTimedOut:
+		rep.runTimedOut++
 	case mutator.NotViable:
 		rep.notViable++
 	case mutator.Runnable:
@@ -215,13 +218,15 @@ func (r *reportStatus) fullRunReport() {
 	killed := fgHiGreen(r.killed)
 	lived := fgRed(r.lived)
 	timedOut := fgGreen(r.timedOut)
+	runTimedOut := fgGreen(r.runTimedOut)
 	notViable := fgHiBlack(r.notViable)
 	skipped := fgHiBlack(r.skipped)
 	notCovered := fgHiYellow(r.notCovered)
 	log.Infoln("")
 	log.Infof("Mutation testing completed in %s\n", r.elapsed.String())
 	log.Infof("Killed: %s, Lived: %s, Not covered: %s\n", killed, lived, notCovered)
-	log.Infof("Timed out: %s, Not viable: %s, Skipped: %s\n", timedOut, notViable, skipped)
+	log.Infof("Timed out: %s, Run timed out: %s, Not viable: %s, Skipped: %s\n",
+		timedOut, runTimedOut, notViable, skipped)
 	log.Infof("Test efficacy: %.2f%%\n", r.tEfficacy)
 	log.Infof("Mutator coverage: %.2f%%\n", r.mCovered)
 }
@@ -279,7 +284,7 @@ func Mutant(m mutator.Mutator) {
 		status = fgRed(m.Status())
 	case mutator.NotCovered:
 		status = fgHiYellow(m.Status())
-	case mutator.TimedOut:
+	case mutator.TimedOut, mutator.RunTimedOut:
 		status = fgGreen(m.Status())
 	case mutator.NotViable, mutator.Skipped:
 		status = fgHiBlack(m.Status())
@@ -348,11 +353,22 @@ func generateDiff(m mutator.Mutator) ([]string, error) {
 }
 
 func padding(s mutator.Status) string {
-	var pad string
-	padLen := 12 - len(s.String())
-	for i := 0; i < padLen; i++ {
-		pad += " "
+	return strings.Repeat(" ", statusColumnWidth-len(s.String()))
+}
+
+// statusColumnWidth is the column the status name is right-aligned in: the
+// longest status name, plus one space to separate it from what follows. Derived
+// from mutator.Statuses rather than declared, so adding a status cannot leave a
+// literal behind that silently stops padding every line.
+var statusColumnWidth = longestStatusNameLen() + 1
+
+func longestStatusNameLen() int {
+	longest := 0
+	for _, s := range mutator.Statuses {
+		if n := len(s.String()); n > longest {
+			longest = n
+		}
 	}
 
-	return pad
+	return longest
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -67,7 +67,7 @@ func TestReport(t *testing.T) {
 				// Limit the time reporting to the first two units (millis are excluded)
 				testingLine +
 				"Killed: 1, Lived: 1, Not covered: 1\n" +
-				"Timed out: 1, Not viable: 1, Skipped: 1\n" +
+				"Timed out: 1, Run timed out: 0, Not viable: 1, Skipped: 1\n" +
 				"Test efficacy: 50.00%\n" +
 				"Mutator coverage: 66.67%\n",
 		},
@@ -80,7 +80,7 @@ func TestReport(t *testing.T) {
 				// Limit the time reporting to the first two units (millis are excluded)
 				testingLine +
 				"Killed: 0, Lived: 0, Not covered: 1\n" +
-				"Timed out: 0, Not viable: 0, Skipped: 0\n" +
+				"Timed out: 0, Run timed out: 0, Not viable: 0, Skipped: 0\n" +
 				"Test efficacy: 0.00%\n" +
 				coverageLine,
 		},
@@ -94,9 +94,30 @@ func TestReport(t *testing.T) {
 				// Limit the time reporting to the first two units (millis are excluded)
 				testingLine +
 				"Killed: 0, Lived: 0, Not covered: 0\n" +
-				"Timed out: 2, Not viable: 0, Skipped: 0\n" +
+				"Timed out: 2, Run timed out: 0, Not viable: 0, Skipped: 0\n" +
 				"Test efficacy: 0.00%\n" +
 				coverageLine,
+		},
+		{
+			// The two timeout kinds are counted apart, and NEITHER enters
+			// test_efficacy. gremlins records which bound claimed a mutant; it
+			// does not decide that a run-phase timeout is a detection, because
+			// that is a policy its consumers own. A run that changed this line's
+			// 50.00% would be gremlins taking that decision for them.
+			name: "reports a run-phase timeout apart from a backstop timeout",
+			mutants: []mutator.Mutator{
+				stubMutant{status: mutator.Killed, mutantType: mutator.ConditionalsNegation, position: fakePosition},
+				stubMutant{status: mutator.Lived, mutantType: mutator.ConditionalsNegation, position: fakePosition},
+				stubMutant{status: mutator.TimedOut, mutantType: mutator.ConditionalsBoundary, position: fakePosition},
+				stubMutant{status: mutator.RunTimedOut, mutantType: mutator.ConditionalsBoundary, position: fakePosition},
+				stubMutant{status: mutator.RunTimedOut, mutantType: mutator.IncrementDecrement, position: fakePosition},
+			},
+			want: "\n" +
+				testingLine +
+				"Killed: 1, Lived: 1, Not covered: 0\n" +
+				"Timed out: 1, Run timed out: 2, Not viable: 0, Skipped: 0\n" +
+				"Test efficacy: 50.00%\n" +
+				"Mutator coverage: 100.00%\n",
 		},
 		{
 			name:    "reports nothing if no result",
@@ -307,7 +328,7 @@ func TestMutantNoDiff(t *testing.T) {
 		}
 		report.Mutant(m)
 
-		want := "       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		want := "         LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
 		got := out.String()
 		if !cmp.Equal(got, want) {
 			t.Error(cmp.Diff(want, got))
@@ -377,7 +398,7 @@ func TestMutantDiff(t *testing.T) {
 				if errOut.Len() > 0 {
 					t.Errorf("unexpected error logged: %q", errOut.String())
 				}
-				want := "       -if x > y {\n       +if x >= y {\n          x = 10\n"
+				want := "         -if x > y {\n         +if x >= y {\n            x = 10\n"
 				got := out.String()
 				if !cmp.Equal(got, want) {
 					t.Error(cmp.Diff(want, got))
@@ -432,13 +453,13 @@ func TestMutantLog(t *testing.T) {
 	got := out.String()
 
 	want := "" +
-		"       LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"      KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		" NOT COVERED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"    RUNNABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"  NOT VIABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"   TIMED OUT CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
-		"     SKIPPED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
+		"         LIVED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"        KILLED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"   NOT COVERED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"      RUNNABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"    NOT VIABLE CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"     TIMED OUT CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n" +
+		"       SKIPPED CONDITIONALS_BOUNDARY at aFolder/aFile.go:12:3\n"
 
 	if !cmp.Equal(got, want) {
 		t.Error(cmp.Diff(got, want))


### PR DESCRIPTION
## Problem

When `gremlins unleash` runs inside a CI job and the runner sends `SIGTERM` at job-timeout (or a developer hits Ctrl-C), two bugs combine to corrupt the output report:

1. `cmd/gremlins/main.go` registers a buffered channel with `signal.Notify` and then `close()`s that channel inside the receiver goroutine. If a second signal arrives — common in CI, where runners typically send `SIGTERM` followed shortly by `SIGKILL`, or with two Ctrl-Cs from a TTY — `os/signal.process` panics with `panic: send on closed channel`.
2. Mutants whose `go test` subprocess is still running at the moment of cancellation are reported as `LIVED`. `mutantExecutor.runTests` rooted the per-test ctx in `context.Background()` rather than the engine's run ctx, so the only ctx error it checked (`DeadlineExceeded`) never fires on cancellation. Execution falls through to the default `return mutator.Lived` branch.

The combined effect: a single SIGTERM produces a panic stack trace **and** a `gremlins.json` where mutants that were never actually tested appear as surviving mutants — quietly deflating `test_efficacy` (`KILLED / (KILLED + LIVED)`) and adding noise to any CI gate that consumes the JSON.

## Repro

Reported by [cerberus](https://github.com/tsouza/cerberus) — run [`26213450154`](https://github.com/tsouza/cerberus/actions/runs/26213450154) on push-to-main commit `8c1b246` had four mutants surviving with the same `Shutting down gracefully...` trace + `send on closed channel` panic. Re-running the workflow reliably reproduces the same four LIVED mutants, all in code paths whose test runtime exceeded the runner's remaining time budget.

## Fix

- **Signal handler (`cmd/gremlins/main.go`)** — stop closing the signal channel. Buffer to 2, and on a second signal call `signal.Stop` and `os.Exit(130)` (`128 + SIGINT`). First signal still cancels the ctx for graceful shutdown.
- **Executor (`internal/engine/executor.go`)** — root the per-test ctx in the engine's run ctx via a new `MutantExecutorDealer.SetRunCtx`. After `run(ctx, cmd)` returns, distinguish `runCtx.Err() != nil` (runner cancelled us) from `DeadlineExceeded` (we hit our own timeout) from the normal exit-code branches. The cancelled-run branch returns the configured shutdown status instead of `LIVED`.
- **New CLI flag `--on-shutdown-status`** (config key `unleash.on-shutdown-status`) with values:
  - `not-run` (default) — record as `NOT COVERED`. Truthful: the mutant was never observed.
  - `timed-out` — record as `TIMED OUT`. Useful if you'd rather have a distinct bucket.
  - `lived` — legacy behaviour, opt-in. Available for backwards compatibility but explicitly discouraged in the docs because it misrepresents the data.
- **Parser** — `mutator.ParseShutdownStatus` centralises the value → Status mapping (case-sensitive aliases: `not-run`/`notrun`, `timed-out`/`timedout`/`timeout`, `lived`).

## BWC

The behaviour change is reachable only on cancellation, so a normal run is byte-for-byte unchanged. The new flag defaults to `not-run`, which is the most accurate semantic for "we never finished testing this mutant". Users who depend on the previous LIVED-on-cancel behaviour can opt back in with `--on-shutdown-status=lived`.

`test_efficacy` is `KILLED / (KILLED + LIVED)`, so with `not-run` (`NotCovered`) cancelled-in-flight mutants no longer skew it — they fall outside both buckets.

## Tests

- `TestShutdownMidRun` (in `internal/engine/executor_test.go`) — spawns a sleeping subprocess via the existing `getCmd`/`TestProcess*` fake-exec pattern, cancels the run ctx 100 ms in, and asserts the mutant arrives on the out-channel with the configured status. Three sub-cases (`not-run` → `NotCovered`, `timed-out` → `TimedOut`, `lived` → `Lived`) pin all three flag values.
- `TestParseShutdownStatus` (in `internal/mutator/mutator_test.go`) — pins the value-parser including aliases and the "unknown input rejected" path.

`go test -race ./...` is green; full suite passes 355 tests across 16 packages.

## Docs

`docs/docs/usage/commands/unleash/index.md` gains an `### On-shutdown status` section under the per-flag reference, with the three values, their semantics, and a recommendation against `lived`.