### PR TITLE
feat: add INVERT_BOOLEAN_LITERALS mutator

### DIFF
--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -254,6 +254,19 @@ Enables/disables the [INVERT BITWISE](../../mutations/invert_bitwise.md) mutant 
 gremlins unleash --invert-bitwise
 ```
 
+### Invert boolean literals
+
+:material-flag: `--invert-boolean-literals`
+· :material-sign-direction: Default: `false`
+
+Enables/disables the
+[INVERT BOOLEAN LITERALS](../../mutations/invert_boolean_literals.md)
+mutant type.
+
+```shell
+gremlins unleash --invert-boolean-literals
+```
+
 ### Invert bitwise assignments
 
 :material-flag: `--invert-bwassign` · :material-sign-direction: Default: `false`

--- a/docs/docs/usage/mutations/index.md
+++ b/docs/docs/usage/mutations/index.md
@@ -24,4 +24,5 @@ Each _mutant type_ can be enabled or disabled, and only a subset of mutations is
 | [INVERT ASSIGNMENTS ](invert_assignments.md)           |  FALSE  |
 | [INVERT BITWISE ](invert_bitwise.md)                   |  FALSE  |
 | [INVERT BWASSIGN ](invert_bitwise_assignments.md)      |  FALSE  |
+| [INVERT BOOLEAN LITERALS](invert_boolean_literals.md)|  FALSE  |
 | [REMOVE_SELF_ASSIGNMENTS ](remove_self_assignments.md) |  FALSE  |

--- a/docs/docs/usage/mutations/invert_boolean_literals.md
+++ b/docs/docs/usage/mutations/invert_boolean_literals.md
@@ -1,0 +1,14 @@
+---
+title: Invert boolean literals
+---
+
+This mutation type inverts boolean literal values `true` and `false`.
+
+| From    | To      |
+|:-------:|:-------:|
+| `true`  | `false` |
+| `false` | `true`  |
+
+This mutator is particularly useful for catching untested state
+assignments (e.g., `isReady = true`) and exposing missing negative test
+paths when functions unconditionally return a boolean literal.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
           - usage/mutations/invert_assignments.md
           - usage/mutations/invert_bitwise.md
           - usage/mutations/invert_bitwise_assignments.md
+          - usage/mutations/invert_boolean_literals.md
           - usage/mutations/invert_logical.md
           - usage/mutations/invert_loop.md
           - usage/mutations/invert_negatives.md

--- a/internal/configuration/mutantenabled.go
+++ b/internal/configuration/mutantenabled.go
@@ -32,6 +32,7 @@ var mutationEnabled = map[mutator.Type]bool{
 	mutator.InvertLoopCtrl:           false,
 	mutator.InvertNegatives:          true,
 	mutator.RemoveSelfAssignments:    false,
+	mutator.InvertBooleanLiterals:    false,
 }
 
 // IsDefaultEnabled returns the default enabled/disabled state of the mutation.

--- a/internal/configuration/mutantenables_test.go
+++ b/internal/configuration/mutantenables_test.go
@@ -74,6 +74,10 @@ func TestMutantDefaultStatus(t *testing.T) {
 			mutantType: mutator.RemoveSelfAssignments,
 			expected:   false,
 		},
+		{
+			mutantType: mutator.InvertBooleanLiterals,
+			expected:   false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -128,13 +128,47 @@ func (mu *Engine) runOnFile(fileName string) {
 
 	ast.Inspect(file, func(node ast.Node) bool {
 		n, ok := NewTokenNode(node)
-		if !ok {
-			return true
+		if ok {
+			mu.findMutations(fileName, set, file, n)
 		}
-		mu.findMutations(fileName, set, file, n)
+
+		mu.findLiteralMutations(fileName, set, file, node)
 
 		return true
 	})
+}
+
+func (mu *Engine) findLiteralMutations(fileName string, set *token.FileSet, file *ast.File, node ast.Node) {
+	const (
+		trueStr  = "true"
+		falseStr = "false"
+	)
+
+	var mType mutator.Type
+
+	var isLiteral bool
+
+	if n, ok := node.(*ast.Ident); ok {
+		if n.Name == trueStr || n.Name == falseStr {
+			mType = mutator.InvertBooleanLiterals
+			isLiteral = true
+		}
+	}
+
+	if !isLiteral {
+		return
+	}
+
+	if !configuration.Get[bool](configuration.MutantTypeEnabledKey(mType)) {
+		return
+	}
+
+	pkg := mu.pkgName(fileName, file.Name.Name)
+	lm := NewLiteralMutant(pkg, set, file, node)
+	lm.SetType(mType)
+	lm.SetStatus(mu.mutationStatus(set.Position(node.Pos())))
+
+	mu.mutantStream <- lm
 }
 
 func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.File, node *NodeToken) {

--- a/internal/engine/literalmutator.go
+++ b/internal/engine/literalmutator.go
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+
+	"github.com/go-gremlins/gremlins/internal/mutator"
+)
+
+const (
+	trueStr      = "true"
+	falseStr     = "false"
+	contextLines = 3
+)
+
+// LiteralMutator is a mutator.Mutator for [ast.Ident] (booleans).
+type LiteralMutator struct {
+	node           ast.Node
+	fs             *token.FileSet
+	file           *ast.File
+	pkg            string
+	workDir        string
+	origFile       []byte
+	origSnippet    []byte
+	mutatedSnippet []byte
+	status         mutator.Status
+	mutantType     mutator.Type
+}
+
+// NewLiteralMutant initializes a LiteralMutator.
+func NewLiteralMutant(pkg string, set *token.FileSet, file *ast.File, node ast.Node) *LiteralMutator {
+	return &LiteralMutator{
+		pkg:  pkg,
+		fs:   set,
+		file: file,
+		node: node,
+	}
+}
+
+// Type returns the mutator.Type of the mutant.Mutator.
+func (m *LiteralMutator) Type() mutator.Type {
+	return m.mutantType
+}
+
+// SetType sets the mutator.Type of the mutant.Mutator.
+func (m *LiteralMutator) SetType(mt mutator.Type) {
+	m.mutantType = mt
+}
+
+// Status returns the mutator.Status of the mutant.Mutator.
+func (m *LiteralMutator) Status() mutator.Status {
+	return m.status
+}
+
+// SetStatus sets the mutator.Status of the mutant.Mutator.
+func (m *LiteralMutator) SetStatus(s mutator.Status) {
+	m.status = s
+}
+
+// Position returns the [token.Position] where the LiteralMutator resides.
+func (m *LiteralMutator) Position() token.Position {
+	return m.fs.Position(m.node.Pos())
+}
+
+// Pos returns the [token.Pos] where the LiteralMutator resides.
+func (m *LiteralMutator) Pos() token.Pos {
+	return m.node.Pos()
+}
+
+// Pkg returns the package name to which the mutant belongs.
+func (m *LiteralMutator) Pkg() string {
+	return m.pkg
+}
+
+// Apply mutates the literal node and writes to disk.
+func (m *LiteralMutator) Apply() error {
+	fileLock(m.Position().Filename).Lock()
+	defer fileLock(m.Position().Filename).Unlock()
+
+	filename := filepath.Join(m.workDir, m.Position().Filename)
+
+	var err error
+
+	m.origFile, err = os.ReadFile(filepath.Clean(filename))
+	if err != nil {
+		return fmt.Errorf("read original file: %w", err)
+	}
+
+	m.origSnippet = extractSnippet(m.origFile, m.Position().Line, contextLines)
+
+	var revert func()
+
+	if n, ok := m.node.(*ast.Ident); ok {
+		old := n.Name
+		if n.Name == trueStr {
+			n.Name = falseStr
+		} else {
+			n.Name = trueStr
+		}
+
+		revert = func() { n.Name = old }
+	}
+
+	if err := m.writeMutatedFile(filename); err != nil {
+		return fmt.Errorf("write mutated file: %w", err)
+	}
+
+	// Rollback here to facilitate the atomicity of the operation.
+	if revert != nil {
+		revert()
+	}
+
+	return nil
+}
+
+func (m *LiteralMutator) writeMutatedFile(filename string) error {
+	w := &bytes.Buffer{}
+
+	err := printer.Fprint(w, m.fs, m.file)
+	if err != nil {
+		return fmt.Errorf("print mutated file: %w", err)
+	}
+
+	payload := w.Bytes()
+
+	err = os.WriteFile(filename, payload, 0o600)
+	if err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	m.mutatedSnippet = extractSnippet(payload, m.Position().Line, contextLines)
+
+	return nil
+}
+
+// Rollback puts back the original file after the test and cleans up the LiteralMutator.
+func (m *LiteralMutator) Rollback() error {
+	defer m.resetOrigFile()
+
+	filename := filepath.Join(m.workDir, m.Position().Filename)
+
+	err := os.WriteFile(filename, m.origFile, 0o600)
+	if err != nil {
+		return fmt.Errorf("rollback file: %w", err)
+	}
+
+	return nil
+}
+
+// SetWorkdir sets the base path on which to Apply and Rollback operations.
+func (m *LiteralMutator) SetWorkdir(path string) {
+	m.workDir = path
+}
+
+// Workdir returns the current working dir in which the Mutator will apply its mutations.
+func (m *LiteralMutator) Workdir() string {
+	return m.workDir
+}
+
+func (m *LiteralMutator) resetOrigFile() {
+	var zeroByte []byte
+
+	m.origFile = zeroByte
+}
+
+// OrigSnippet returns the original code snippet around the mutation point.
+func (m *LiteralMutator) OrigSnippet() []byte {
+	return m.origSnippet
+}
+
+// MutatedSnippet returns the mutated code snippet around the mutation point.
+func (m *LiteralMutator) MutatedSnippet() []byte {
+	return m.mutatedSnippet
+}

--- a/internal/engine/literalmutator_test.go
+++ b/internal/engine/literalmutator_test.go
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2022 The Gremlins Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package engine_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-gremlins/gremlins/internal/engine"
+	"github.com/go-gremlins/gremlins/internal/mutator"
+)
+
+func TestLiteralMutator_ApplyAndRollback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		origCode   string
+		targetNode string
+		wantCode   string
+	}{
+		{
+			name: "true to false",
+			origCode: `package main
+func test() bool {
+	return true
+}
+`,
+			targetNode: "true",
+			wantCode:   "package main\n\nfunc test() bool {\n\treturn false\n}\n",
+		},
+		{
+			name: "false to true",
+			origCode: `package main
+func test() bool {
+	return false
+}
+`,
+			targetNode: "false",
+			wantCode:   "package main\n\nfunc test() bool {\n\treturn true\n}\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			fileName := "test_literal.go"
+			filePath := filepath.Join(tmpDir, fileName)
+
+			err := os.WriteFile(filePath, []byte(tc.origCode), 0o600)
+			if err != nil {
+				t.Fatalf("failed to write file: %v", err)
+			}
+
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, fileName, tc.origCode, 0)
+			if err != nil {
+				t.Fatalf("failed to parse file: %v", err)
+			}
+
+			var targetNode ast.Node
+			ast.Inspect(f, func(node ast.Node) bool {
+				if ident, ok := node.(*ast.Ident); ok && ident.Name == tc.targetNode {
+					targetNode = ident
+
+					return false
+				}
+
+				return true
+			})
+
+			if targetNode == nil {
+				t.Fatalf("failed to find %q ident in AST", tc.targetNode)
+			}
+
+			m := engine.NewLiteralMutant("main", fset, f, targetNode)
+			m.SetWorkdir(tmpDir)
+
+			err = m.Apply()
+			if err != nil {
+				t.Fatalf("failed to apply mutation: %v", err)
+			}
+
+			mutatedContent, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatalf("failed to read mutated file: %v", err)
+			}
+
+			if string(mutatedContent) != tc.wantCode {
+				t.Errorf("unexpected mutated content:\nwant:\n%q\ngot:\n%q", tc.wantCode, string(mutatedContent))
+			}
+
+			err = m.Rollback()
+			if err != nil {
+				t.Fatalf("failed to rollback mutation: %v", err)
+			}
+
+			rolledBackContent, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Fatalf("failed to read rolled back file: %v", err)
+			}
+
+			if string(rolledBackContent) != tc.origCode {
+				t.Errorf("unexpected rolled back content: %q", string(rolledBackContent))
+			}
+		})
+	}
+}
+
+func TestLiteralMutator_Getters(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	fileName := "test_literal.go"
+	filePath := filepath.Join(tmpDir, fileName)
+
+	origCode := `package main
+func test() bool {
+	return true
+}
+`
+	err := os.WriteFile(filePath, []byte(origCode), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, fileName, origCode, 0)
+	if err != nil {
+		t.Fatalf("failed to parse file: %v", err)
+	}
+
+	var targetNode ast.Node
+	ast.Inspect(f, func(node ast.Node) bool {
+		if ident, ok := node.(*ast.Ident); ok && ident.Name == "true" {
+			targetNode = ident
+
+			return false
+		}
+
+		return true
+	})
+
+	m := engine.NewLiteralMutant("main", fset, f, targetNode)
+	m.SetWorkdir(tmpDir)
+	m.SetType(mutator.InvertBooleanLiterals)
+	m.SetStatus(mutator.Runnable)
+
+	if m.Type() != mutator.InvertBooleanLiterals {
+		t.Errorf("expected type %v, got %v", mutator.InvertBooleanLiterals, m.Type())
+	}
+
+	if m.Status() != mutator.Runnable {
+		t.Errorf("expected status %v, got %v", mutator.Runnable, m.Status())
+	}
+
+	if m.Pos() != targetNode.Pos() {
+		t.Errorf("expected pos %v, got %v", targetNode.Pos(), m.Pos())
+	}
+
+	if m.Pkg() != "main" {
+		t.Errorf("expected pkg main, got %v", m.Pkg())
+	}
+
+	if m.Workdir() != tmpDir {
+		t.Errorf("expected workdir %v, got %v", tmpDir, m.Workdir())
+	}
+
+	err = m.Apply()
+	if err != nil {
+		t.Fatalf("failed to apply: %v", err)
+	}
+
+	if len(m.OrigSnippet()) == 0 {
+		t.Error("expected non-empty orig snippet")
+	}
+
+	if len(m.MutatedSnippet()) == 0 {
+		t.Error("expected non-empty mutated snippet")
+	}
+}

--- a/internal/mutator/mutator.go
+++ b/internal/mutator/mutator.go
@@ -84,6 +84,7 @@ const (
 	InvertLoopCtrl
 	InvertNegatives
 	RemoveSelfAssignments
+	InvertBooleanLiterals
 )
 
 // Types allows to iterate over Type.
@@ -99,6 +100,7 @@ var Types = []Type{
 	InvertLoopCtrl,
 	InvertNegatives,
 	RemoveSelfAssignments,
+	InvertBooleanLiterals,
 }
 
 func (mt Type) String() string {
@@ -125,6 +127,8 @@ func (mt Type) String() string {
 		return "INVERT_BWASSIGN"
 	case RemoveSelfAssignments:
 		return "REMOVE_SELF_ASSIGNMENTS"
+	case InvertBooleanLiterals:
+		return "INVERT_BOOLEAN_LITERALS"
 
 	default:
 		panic("this should not happen")

--- a/internal/report/internal/structure.go
+++ b/internal/report/internal/structure.go
@@ -59,4 +59,5 @@ type MutatorType struct {
 	InvertLoopCtrl           int `json:"invert_loop_ctrl,omitempty"`
 	InvertNegatives          int `json:"invert_negatives,omitempty"`
 	RemoveSelfAssignments    int `json:"remove_self_assignments,omitempty"`
+	InvertBooleanLiterals    int `json:"invertBooleanLiterals,omitempty"`
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -147,6 +147,8 @@ func reportMutatorType(m mutator.Mutator, rep *reportStatus) {
 		rep.mutatorStatistics.InvertNegatives++
 	case mutator.RemoveSelfAssignments:
 		rep.mutatorStatistics.RemoveSelfAssignments++
+	case mutator.InvertBooleanLiterals:
+		rep.mutatorStatistics.InvertBooleanLiterals++
 	}
 }
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -89,12 +89,13 @@ func TestReport(t *testing.T) {
 			mutants: []mutator.Mutator{
 				stubMutant{status: mutator.TimedOut, mutantType: mutator.ConditionalsNegation, position: fakePosition},
 				stubMutant{status: mutator.TimedOut, mutantType: mutator.ConditionalsBoundary, position: fakePosition},
+				stubMutant{status: mutator.TimedOut, mutantType: mutator.InvertBooleanLiterals, position: fakePosition},
 			},
 			want: "\n" +
 				// Limit the time reporting to the first two units (millis are excluded)
 				testingLine +
 				"Killed: 0, Lived: 0, Not covered: 0\n" +
-				"Timed out: 2, Not viable: 0, Skipped: 0\n" +
+				"Timed out: 3, Not viable: 0, Skipped: 0\n" +
 				"Test efficacy: 0.00%\n" +
 				coverageLine,
 		},


### PR DESCRIPTION
# Gremlins PR: Boolean Literal Inversion Mutator

## Goal
Implement a new mutator in `go-gremlins/gremlins` that targets boolean literals (`true` and `false`). This will allow Gremlins to catch untested state assignments and missing return paths without generating the noise associated with structural mutations.

## Rationale
Currently, Gremlins is blind to missing test coverage in two major areas involving boolean literals:
1. **Unconditional Returns**: Functions that return boolean literals inside loops or conditional blocks.
2. **Untested Assignments**: State flags or domain variables being assigned boolean literals (e.g., `target.needsPullRetry = false`), where tests don't actually verify the resulting state.

### Example 1: The Missing Negative Return
```go
func hasTag(tags []string, target string) bool {
    for _, tag := range tags {
        if tag == target {
            return true // If mutated to false, a positive test will fail
        }
    }
    return false // If mutated to true, only a negative test will fail
}
```
If a developer only writes positive test cases, mutating the final `return false` to `return true` will expose the lack of negative test coverage.

### Example 2: The Untested Assignment
```go
func (r *Runner) pull(...) {
    // ... logic ...
    target.needsPushRetry = false // Is this state actually asserted in tests?
}
```
If the tests only assert on the final outcome of the pull and not the internal flag, changing `false` to `true` will expose the blind spot.

## Implementation Details (Simplified "Parallel Engine" Architecture)
To avoid breaking the hyper-optimized `TokenMutator` core engine, this feature should be implemented as a standalone, parallel mutator.

1. **Leave Core Intact**: Do not modify `NodeToken` or the existing `TokenMutator` interface. They rely on integer swapping and should remain untouched to prevent performance regressions.
2. **Create `LiteralMutator`**: Build a new struct that implements the base `Mutant` interface. It will hold references to `ast.Ident` nodes and manage string swapping.
3. **AST Walker Integration**: Inject a parallel check in the main AST `Visit` function to intercept boolean literals *before* or *alongside* the `NewTokenNode` check:
   ```go
   // EXISTING CORE (Do not modify)
   if tokenNode, ok := NewTokenNode(node); ok {
       // Run standard TokenMutators
   }

   // NEW PARALLEL LOGIC
   if ident, ok := node.(*ast.Ident); ok {
       if ident.Name == "true" || ident.Name == "false" {
           // Run LiteralMutator for Booleans
       }
   }
   ```
4. **Configuration**: Register this as a non-default mutator (e.g., `INVERT_BOOLEAN_LITERALS`) so users can opt-in.

## Expected Outcomes
This approach brings critical assignment-based checks into the fast, compiler-safe world of token mutation. By utilizing a "Parallel Engine" architecture, the PR provides massive value with minimal risk to the maintainers' existing, highly optimized codebase, while avoiding the "scattergun" noise of string or numeric literal mutations.