### PR TITLE
fix(engine): add -count=1 and scan output for FAIL in integration mode

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -247,9 +247,7 @@ func (m *mutantExecutor) getTestArgs(pkg string) []string {
 	// Here we add some seconds to the timeout to be sure it's gremlins that catches the test
 	// timeout and not the test itself. The timeout on the test prevents the test.* processes
 	// from hanging forever.
-	args = append(args, "-timeout", (2*time.Second + m.testExecutionTime).String())
-	args = append(args, "-failfast")
-	args = append(args, "-count=1")
+	args = append(args, "-timeout", (2*time.Second + m.testExecutionTime).String(), "-failfast", "-count=1")
 
 	if m.testCPU != 0 {
 		args = append(args, "-cpu", fmt.Sprintf("%d", m.testCPU))

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -17,12 +17,14 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -210,6 +212,10 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	cmd.Env = append(cmd.Env, os.Environ()...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GOTMPDIR=%s", m.wdDealer.WorkDir()))
 
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
 	// Set up process group for killing entire process tree
 	setupProcessGroup(cmd)
 
@@ -221,6 +227,13 @@ func (m *mutantExecutor) runTests(rootDir, pkg string) mutator.Status {
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		return getTestFailedStatus(exitErr.ExitCode())
+	}
+
+	// Go 1.26 has a bug where `go test -failfast ./...` exits with code 0 even
+	// when a t.Parallel() test panics in a multi-package run. Scanning the output
+	// for a FAIL line catches these false-negative results.
+	if outputContainsFail(buf.String()) {
+		return mutator.Killed
 	}
 
 	return mutator.Lived
@@ -236,6 +249,7 @@ func (m *mutantExecutor) getTestArgs(pkg string) []string {
 	// from hanging forever.
 	args = append(args, "-timeout", (2*time.Second + m.testExecutionTime).String())
 	args = append(args, "-failfast")
+	args = append(args, "-count=1")
 
 	if m.testCPU != 0 {
 		args = append(args, "-cpu", fmt.Sprintf("%d", m.testCPU))
@@ -285,6 +299,16 @@ func run(ctx context.Context, cmd *exec.Cmd) error {
 		// Process completed normally
 		return err
 	}
+}
+
+func outputContainsFail(output string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "FAIL") {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getTestFailedStatus(exitCode int) mutator.Status {

--- a/internal/engine/executor_internal_test.go
+++ b/internal/engine/executor_internal_test.go
@@ -37,42 +37,42 @@ func TestGetTestArgs(t *testing.T) {
 		"should_not_include_tags_flag_when_build_tags_are_empty": {
 			testExecutionTime: 10 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "12s", "-failfast", "-count=1", "example.com/my/package"},
 		},
 		"should_include_tags_flag_when_build_tags_are_set": {
 			buildTags:         "tag1,tag2",
 			testExecutionTime: 10 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-tags", "tag1,tag2", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-tags", "tag1,tag2", "-timeout", "12s", "-failfast", "-count=1", "example.com/my/package"},
 		},
 		"should_compute_timeout_as_two_seconds_plus_execution_time": {
 			testExecutionTime: 30 * time.Second,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "32s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "32s", "-failfast", "-count=1", "example.com/my/package"},
 		},
 		"should_not_include_cpu_flag_when_test_cpu_is_zero": {
 			testExecutionTime: 10 * time.Second,
 			testCPU:           0,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "12s", "-failfast", "-count=1", "example.com/my/package"},
 		},
 		"should_include_cpu_flag_when_test_cpu_is_nonzero": {
 			testExecutionTime: 10 * time.Second,
 			testCPU:           4,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "-cpu", "4", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "12s", "-failfast", "-count=1", "-cpu", "4", "example.com/my/package"},
 		},
 		"should_use_package_path_when_integration_mode_is_disabled": {
 			testExecutionTime: 10 * time.Second,
 			integrationMode:   false,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "example.com/my/package"},
+			want:              []string{"test", "-timeout", "12s", "-failfast", "-count=1", "example.com/my/package"},
 		},
 		"should_use_dot_dot_dot_path_when_integration_mode_is_enabled": {
 			testExecutionTime: 10 * time.Second,
 			integrationMode:   true,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-timeout", "12s", "-failfast", "./..."},
+			want:              []string{"test", "-timeout", "12s", "-failfast", "-count=1", "./..."},
 		},
 		"should_include_all_flags_when_all_options_are_configured": {
 			buildTags:         "integration",
@@ -80,7 +80,7 @@ func TestGetTestArgs(t *testing.T) {
 			testCPU:           2,
 			integrationMode:   true,
 			pkg:               "example.com/my/package",
-			want:              []string{"test", "-tags", "integration", "-timeout", "12s", "-failfast", "-cpu", "2", "./..."},
+			want:              []string{"test", "-tags", "integration", "-timeout", "12s", "-failfast", "-count=1", "-cpu", "2", "./..."},
 		},
 	}
 
@@ -97,6 +97,51 @@ func TestGetTestArgs(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, sut.getTestArgs(tc.pkg)); diff != "" {
 				t.Errorf("getTestArgs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestOutputContainsFail(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		output string
+		want   bool
+	}{
+		"empty output returns false": {
+			output: "",
+			want:   false,
+		},
+		"ok output returns false": {
+			output: "ok  \texample.com/my/package\t0.123s\n",
+			want:   false,
+		},
+		"FAIL line returns true": {
+			output: "FAIL\texample.com/my/package\t0.456s\n",
+			want:   true,
+		},
+		"FAIL at start of line with leading whitespace returns true": {
+			output: "  FAIL\texample.com/my/package\t0.456s\n",
+			want:   true,
+		},
+		"mixed output with FAIL line returns true": {
+			output: "ok  \texample.com/other\t0.010s\nFAIL\texample.com/my/package\t0.456s\n",
+			want:   true,
+		},
+		"word containing FAIL but not at start returns false": {
+			output: "some text FAILURE here\n",
+			want:   false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := outputContainsFail(tc.output)
+			if got != tc.want {
+				t.Errorf("outputContainsFail(%q) = %v, want %v", tc.output, got, tc.want)
 			}
 		})
 	}

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -151,6 +151,12 @@ func TestMutatorTestExecution(t *testing.T) {
 			mutantStatus:  mutator.Runnable,
 			wantMutStatus: mutator.NotViable,
 		},
+		{
+			name:          "if tests exit 0 but output contains FAIL then mutation is KILLED",
+			testResult:    fakeExecCommandZeroExitWithFAILOutput,
+			mutantStatus:  mutator.Runnable,
+			wantMutStatus: mutator.Killed,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -308,7 +314,7 @@ func TestMutatorRun(t *testing.T) {
 			if tc.timeoutCoefficient != 0 {
 				wantTimeout = 2*time.Second + expectedTimeout*time.Duration(tc.timeoutCoefficient)
 			}
-			want := fmt.Sprintf("go test -tags %s -timeout %s -failfast %s", tc.tags, wantTimeout, tc.wantPath)
+			want := fmt.Sprintf("go test -tags %s -timeout %s -failfast -count=1 %s", tc.tags, wantTimeout, tc.wantPath)
 			got := fmt.Sprintf("go %v", strings.Join(holder.args, " "))
 
 			if !cmp.Equal(got, want) {
@@ -440,6 +446,14 @@ func TestProcessBuildFailure(_ *testing.T) {
 		return
 	}
 	os.Exit(2) // skipcq: RVV-A0003
+}
+
+func TestProcessZeroExitWithFAILOutput(_ *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	fmt.Fprintln(os.Stdout, "FAIL\texample.com/my/package\t0.456s")
+	os.Exit(0) // skipcq: RVV-A0003
 }
 
 func TestMutatorRunInTheCorrectFolder(t *testing.T) {
@@ -580,6 +594,13 @@ func fakeExecCommandTestsFailure(ctx context.Context, command string, args ...st
 
 func fakeExecCommandBuildFailure(ctx context.Context, command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestProcessBuildFailure", "--", command}
+	cs = append(cs, args...)
+
+	return getCmd(ctx, cs)
+}
+
+func fakeExecCommandZeroExitWithFAILOutput(ctx context.Context, command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestProcessZeroExitWithFAILOutput", "--", command}
 	cs = append(cs, args...)
 
 	return getCmd(ctx, cs)


### PR DESCRIPTION
## Proposed changes

Resolves #272.

Integration mode (`-i`) reported mutants as `LIVED` even when existing tests should have caught them. Two root causes:

**1. Missing `-count=1`:** `getTestArgs` did not pass `-count=1` to `go test`, so Go's test cache returned cached `ok` results from a previous clean run. The mutated code was never actually tested; Gremlins saw exit code 0 → `LIVED`.

**2. Go 1.26 exit-code bug:** when `go test -failfast ./...` runs across multiple packages and a `t.Parallel()` test panics, the process exits with code `0` instead of `1`. Gremlins saw exit code 0 → `LIVED`. This only affects integration mode because non-integration mode runs a single-package test which always returns the correct exit code.

**Fix:**

- Add `-count=1` to `getTestArgs` (disables test cache for all runs — correct behaviour for mutation testing regardless of mode).
- Capture `go test` combined stdout/stderr into a `bytes.Buffer`; after the exit-code check, scan the output for a line beginning with `FAIL` via the new `outputContainsFail` helper. A `FAIL` line always appears in `go test` output when a package fails, even when the exit code is `0`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

`outputContainsFail` checks for a leading `FAIL` token (after trimming whitespace) rather than a substring match, avoiding false positives from words like `FAILURE` appearing elsewhere in test output.