### PR TITLE
diff: prepend module path for monorepo --diff support

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -159,7 +159,7 @@ func cleanUp(wd string) {
 }
 
 func run(ctx context.Context, mod gomodule.GoModule, workDir string) (report.Results, error) {
-	fDiff, err := diff.New()
+	fDiff, err := diff.New(mod.Root, mod.CallingDir)
 	if err != nil {
 		return report.Results{}, err
 	}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3,6 +3,7 @@ package diff
 
 import (
 	"go/token"
+	"path/filepath"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 )
@@ -16,10 +17,41 @@ type Change struct {
 	EndLine   int
 }
 
-// Diff maps file names to their list of changes.
-type Diff map[FileName][]Change
+// Diff maps file names to their list of changes and carries path
+// information for monorepo support.
+//
+// moduleRel is the relative path from the git repo root to the Go module root
+// (e.g. "service-a"). callingDir is the relative path from the module root
+// to the current working directory. These are prepended to pos.Filename
+// during IsChanged lookups so that git-root-relative diff keys match
+// module-root-relative token positions.
+type Diff struct {
+	changes    map[FileName][]Change
+	moduleRel  string
+	callingDir string
+}
 
-func newDiff(files []*gitdiff.File) Diff {
+// FromChanges creates a Diff from a pre-built changes map, bypassing git diff.
+// This is used in tests and when the caller already has a changes map.
+func FromChanges(changes map[FileName][]Change) Diff {
+	return Diff{changes: changes}
+}
+
+// WithModuleRel sets the module relative path (from git root to module root).
+func (d Diff) WithModuleRel(rel string) Diff {
+	d.moduleRel = rel
+
+	return d
+}
+
+// WithCallingDir sets the calling directory (from module root to CWD).
+func (d Diff) WithCallingDir(dir string) Diff {
+	d.callingDir = dir
+
+	return d
+}
+
+func newDiff(files []*gitdiff.File, moduleRel, callingDir string) Diff {
 	result := map[FileName][]Change{}
 
 	for _, file := range files {
@@ -28,7 +60,11 @@ func newDiff(files []*gitdiff.File) Diff {
 		result[name] = changes
 	}
 
-	return result
+	return Diff{
+		changes:    result,
+		moduleRel:  moduleRel,
+		callingDir: callingDir,
+	}
 }
 
 func newChanges(file *gitdiff.File) (FileName, []Change) {
@@ -53,11 +89,12 @@ func newChanges(file *gitdiff.File) (FileName, []Change) {
 // IsChanged returns true if the given position is within a changed region.
 // If the diff is empty, it returns true for all positions.
 func (d Diff) IsChanged(pos token.Position) bool {
-	if len(d) == 0 {
+	if len(d.changes) == 0 {
 		return true
 	}
 
-	fileDiff := d[FileName(pos.Filename)]
+	key := FileName(filepath.Join(d.moduleRel, d.callingDir, pos.Filename))
+	fileDiff := d.changes[key]
 
 	for _, change := range fileDiff {
 		if pos.Line >= change.StartLine && pos.Line <= change.EndLine {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -39,16 +39,20 @@ func FromChanges(changes map[FileName][]Change) Diff {
 
 // WithModuleRel sets the module relative path (from git root to module root).
 func (d Diff) WithModuleRel(rel string) Diff {
-	d.moduleRel = rel
-
-	return d
+	return Diff{
+		changes:    d.changes,
+		moduleRel:  rel,
+		callingDir: d.callingDir,
+	}
 }
 
 // WithCallingDir sets the calling directory (from module root to CWD).
 func (d Diff) WithCallingDir(dir string) Diff {
-	d.callingDir = dir
-
-	return d
+	return Diff{
+		changes:    d.changes,
+		moduleRel:  d.moduleRel,
+		callingDir: dir,
+	}
 }
 
 func newDiff(files []*gitdiff.File, moduleRel, callingDir string) Diff {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3,7 +3,8 @@ package diff
 
 import (
 	"go/token"
-	"path/filepath"
+	"path"
+	"strings"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 )
@@ -97,7 +98,10 @@ func (d Diff) IsChanged(pos token.Position) bool {
 		return true
 	}
 
-	key := FileName(filepath.Join(d.moduleRel, d.callingDir, pos.Filename))
+	// Diff keys always use "/" (git's own convention), regardless of OS, so the
+	// prefix is joined with path.Join rather than filepath.Join, and each part is
+	// normalised to "/" in case it was built with filepath.Rel/filepath.Join on Windows.
+	key := FileName(path.Join(toSlash(d.moduleRel), toSlash(d.callingDir), toSlash(pos.Filename)))
 	fileDiff := d.changes[key]
 
 	for _, change := range fileDiff {
@@ -107,4 +111,10 @@ func (d Diff) IsChanged(pos token.Position) bool {
 	}
 
 	return false
+}
+
+// toSlash normalises path separators to "/", regardless of the host OS,
+// since diff keys are always built from git's forward-slash paths.
+func toSlash(s string) string {
+	return strings.ReplaceAll(s, `\`, "/")
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -14,8 +14,10 @@ type FileName string
 
 // Change represents a contiguous range of changed lines in a file.
 type Change struct {
+	// StartLine is the first line of the changed region (1-indexed).
 	StartLine int
-	EndLine   int
+	// EndLine is the last line of the changed region (1-indexed, inclusive).
+	EndLine int
 }
 
 // Diff maps file names to their list of changes and carries path

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -16,40 +16,126 @@ func TestDiff_IsChanged(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "must be changed on nil Diff",
-			d:    nil,
+			name: "must be changed on zero Diff",
+			d:    Diff{},
 			pos:  token.Position{},
 			want: true,
 		},
 		{
 			name: "must be changed on empty Diff",
-			d:    map[FileName][]Change{},
+			d:    Diff{changes: map[FileName][]Change{}},
 			pos:  token.Position{},
 			want: true,
 		},
 		{
 			name: "must be changed if in range",
-			d: map[FileName][]Change{
-				"test": {{StartLine: 21, EndLine: 21}},
+			d: Diff{
+				changes: map[FileName][]Change{
+					"test": {{StartLine: 21, EndLine: 21}},
+				},
 			},
 			pos:  token.Position{Filename: "test", Line: 21},
 			want: true,
 		},
 		{
 			name: "must be unchanged if outside range",
-			d: map[FileName][]Change{
-				"test": {{StartLine: 21, EndLine: 21}},
+			d: Diff{
+				changes: map[FileName][]Change{
+					"test": {{StartLine: 21, EndLine: 21}},
+				},
 			},
 			pos:  token.Position{Filename: "test", Line: 22},
 			want: false,
 		},
 		{
 			name: "must be unchanged if no such file",
-			d: map[FileName][]Change{
-				"test": {{StartLine: 21, EndLine: 21}},
+			d: Diff{
+				changes: map[FileName][]Change{
+					"test": {{StartLine: 21, EndLine: 21}},
+				},
 			},
 			pos:  token.Position{Filename: "test1", Line: 21},
 			want: false,
+		},
+		{
+			name: "monorepo single service: prepend moduleRel",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel: "service-a",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 15},
+			want: true,
+		},
+		{
+			name: "monorepo single service: no match outside range",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel: "service-a",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 25},
+			want: false,
+		},
+		{
+			name: "monorepo subdirectory: prepend moduleRel and callingDir",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/cmd/main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel:  "service-a",
+				callingDir: "cmd",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 15},
+			want: true,
+		},
+		{
+			name: "monorepo multiple services: no collision",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					"service-b/main.go": {{StartLine: 30, EndLine: 40}},
+				},
+				moduleRel: "service-a",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 15},
+			want: true,
+		},
+		{
+			name: "monorepo multiple services: other service not matched",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					"service-b/main.go": {{StartLine: 30, EndLine: 40}},
+				},
+				moduleRel: "service-b",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 15},
+			want: false,
+		},
+		{
+			name: "flat repo (moduleRel='.'): resolves to same key",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel: ".",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 15},
+			want: true,
+		},
+		{
+			name: "empty callingDir is not prepended",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel: "service-a",
+			},
+			pos:  token.Position{Filename: "main.go", Line: 15},
+			want: true,
 		},
 	}
 	for _, tt := range tests {
@@ -77,11 +163,43 @@ func Test_newDiff(t *testing.T) {
 	}
 
 	expected := Diff{
-		"test1": {{StartLine: 25, EndLine: 25}},
-		"test2": {{StartLine: 25, EndLine: 25}},
+		changes: map[FileName][]Change{
+			"test1": {{StartLine: 25, EndLine: 25}},
+			"test2": {{StartLine: 25, EndLine: 25}},
+		},
 	}
 
-	result := newDiff(files)
+	result := newDiff(files, "", "")
+	if !reflect.DeepEqual(result, expected) {
+		t.Log("want", expected)
+		t.Log("got", result)
+		t.Fatalf("unexpected newDiff result")
+	}
+}
+
+func Test_newDiff_withModuleRel(t *testing.T) {
+	fragments := []*gitdiff.TextFragment{fragment(21, 1)}
+
+	files := []*gitdiff.File{
+		{
+			NewName:       "service-a/test1",
+			TextFragments: fragments,
+		},
+		{
+			NewName:       "service-b/test2",
+			TextFragments: fragments,
+		},
+	}
+
+	expected := Diff{
+		changes: map[FileName][]Change{
+			"service-a/test1": {{StartLine: 25, EndLine: 25}},
+			"service-b/test2": {{StartLine: 25, EndLine: 25}},
+		},
+		moduleRel: "service-a",
+	}
+
+	result := newDiff(files, "service-a", "")
 	if !reflect.DeepEqual(result, expected) {
 		t.Log("want", expected)
 		t.Log("got", result)
@@ -118,6 +236,48 @@ func Test_newChanges(t *testing.T) {
 		t.Log("want", expect)
 		t.Log("got", changes)
 		t.Fatalf("unexpected newChanges result")
+	}
+}
+
+func TestFromChanges(t *testing.T) {
+	d := FromChanges(map[FileName][]Change{
+		"file.go": {{StartLine: 1, EndLine: 5}},
+	})
+	if d.changes == nil {
+		t.Fatal("changes should not be nil")
+	}
+	if len(d.changes) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(d.changes))
+	}
+	if d.moduleRel != "" || d.callingDir != "" {
+		t.Fatal("moduleRel and callingDir should be empty")
+	}
+}
+
+func TestDiffWithModuleRel(t *testing.T) {
+	d := FromChanges(map[FileName][]Change{
+		"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+	}).WithModuleRel("service-a")
+
+	pos := token.Position{Filename: "main.go", Line: 15}
+	if !d.IsChanged(pos) {
+		t.Error("expected IsChanged to match with moduleRel prepended")
+	}
+
+	pos2 := token.Position{Filename: "other.go", Line: 15}
+	if d.IsChanged(pos2) {
+		t.Error("expected IsChanged to not match unrelated file")
+	}
+}
+
+func TestDiffWithCallingDir(t *testing.T) {
+	d := FromChanges(map[FileName][]Change{
+		"service-a/cmd/main.go": {{StartLine: 10, EndLine: 20}},
+	}).WithModuleRel("service-a").WithCallingDir("cmd")
+
+	pos := token.Position{Filename: "main.go", Line: 15}
+	if !d.IsChanged(pos) {
+		t.Error("expected IsChanged to match with moduleRel and callingDir prepended")
 	}
 }
 

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 )
 
+const (
+	svcAPref = "service-a"
+	svcAFile = svcAPref + "/main.go"
+	flatFile = "main.go"
+)
+
 func TestDiff_IsChanged(t *testing.T) {
 	tests := []struct {
 		name string
@@ -61,22 +67,22 @@ func TestDiff_IsChanged(t *testing.T) {
 			name: "monorepo single service: prepend moduleRel",
 			d: Diff{
 				changes: map[FileName][]Change{
-					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					svcAFile: {{StartLine: 10, EndLine: 20}},
 				},
-				moduleRel: "service-a",
+				moduleRel: svcAPref,
 			},
-			pos:  token.Position{Filename: "main.go", Line: 15},
+			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: true,
 		},
 		{
 			name: "monorepo single service: no match outside range",
 			d: Diff{
 				changes: map[FileName][]Change{
-					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					svcAFile: {{StartLine: 10, EndLine: 20}},
 				},
-				moduleRel: "service-a",
+				moduleRel: svcAPref,
 			},
-			pos:  token.Position{Filename: "main.go", Line: 25},
+			pos:  token.Position{Filename: flatFile, Line: 25},
 			want: false,
 		},
 		{
@@ -85,56 +91,56 @@ func TestDiff_IsChanged(t *testing.T) {
 				changes: map[FileName][]Change{
 					"service-a/cmd/main.go": {{StartLine: 10, EndLine: 20}},
 				},
-				moduleRel:  "service-a",
+				moduleRel:  svcAPref,
 				callingDir: "cmd",
 			},
-			pos:  token.Position{Filename: "main.go", Line: 15},
+			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: true,
 		},
 		{
 			name: "monorepo multiple services: no collision",
 			d: Diff{
 				changes: map[FileName][]Change{
-					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					svcAFile:            {{StartLine: 10, EndLine: 20}},
 					"service-b/main.go": {{StartLine: 30, EndLine: 40}},
 				},
-				moduleRel: "service-a",
+				moduleRel: svcAPref,
 			},
-			pos:  token.Position{Filename: "main.go", Line: 15},
+			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: true,
 		},
 		{
 			name: "monorepo multiple services: other service not matched",
 			d: Diff{
 				changes: map[FileName][]Change{
-					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					svcAFile:            {{StartLine: 10, EndLine: 20}},
 					"service-b/main.go": {{StartLine: 30, EndLine: 40}},
 				},
 				moduleRel: "service-b",
 			},
-			pos:  token.Position{Filename: "main.go", Line: 15},
+			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: false,
 		},
 		{
 			name: "flat repo (moduleRel='.'): resolves to same key",
 			d: Diff{
 				changes: map[FileName][]Change{
-					"main.go": {{StartLine: 10, EndLine: 20}},
+					flatFile: {{StartLine: 10, EndLine: 20}},
 				},
 				moduleRel: ".",
 			},
-			pos:  token.Position{Filename: "main.go", Line: 15},
+			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: true,
 		},
 		{
 			name: "empty callingDir is not prepended",
 			d: Diff{
 				changes: map[FileName][]Change{
-					"service-a/main.go": {{StartLine: 10, EndLine: 20}},
+					svcAFile: {{StartLine: 10, EndLine: 20}},
 				},
-				moduleRel: "service-a",
+				moduleRel: svcAPref,
 			},
-			pos:  token.Position{Filename: "main.go", Line: 15},
+			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: true,
 		},
 	}
@@ -196,10 +202,10 @@ func Test_newDiff_withModuleRel(t *testing.T) {
 			"service-a/test1": {{StartLine: 25, EndLine: 25}},
 			"service-b/test2": {{StartLine: 25, EndLine: 25}},
 		},
-		moduleRel: "service-a",
+		moduleRel: svcAPref,
 	}
 
-	result := newDiff(files, "service-a", "")
+	result := newDiff(files, svcAPref, "")
 	if !reflect.DeepEqual(result, expected) {
 		t.Log("want", expected)
 		t.Log("got", result)
@@ -256,10 +262,10 @@ func TestFromChanges(t *testing.T) {
 
 func TestDiffWithModuleRel(t *testing.T) {
 	d := FromChanges(map[FileName][]Change{
-		"service-a/main.go": {{StartLine: 10, EndLine: 20}},
-	}).WithModuleRel("service-a")
+		svcAFile: {{StartLine: 10, EndLine: 20}},
+	}).WithModuleRel(svcAPref)
 
-	pos := token.Position{Filename: "main.go", Line: 15}
+	pos := token.Position{Filename: flatFile, Line: 15}
 	if !d.IsChanged(pos) {
 		t.Error("expected IsChanged to match with moduleRel prepended")
 	}
@@ -273,9 +279,9 @@ func TestDiffWithModuleRel(t *testing.T) {
 func TestDiffWithCallingDir(t *testing.T) {
 	d := FromChanges(map[FileName][]Change{
 		"service-a/cmd/main.go": {{StartLine: 10, EndLine: 20}},
-	}).WithModuleRel("service-a").WithCallingDir("cmd")
+	}).WithModuleRel(svcAPref).WithCallingDir("cmd")
 
-	pos := token.Position{Filename: "main.go", Line: 15}
+	pos := token.Position{Filename: flatFile, Line: 15}
 	if !d.IsChanged(pos) {
 		t.Error("expected IsChanged to match with moduleRel and callingDir prepended")
 	}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -143,6 +143,29 @@ func TestDiff_IsChanged(t *testing.T) {
 			pos:  token.Position{Filename: flatFile, Line: 15},
 			want: true,
 		},
+		{
+			name: "windows-style separators in moduleRel/callingDir still match forward-slash diff keys",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/cmd/main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel:  `service-a`,
+				callingDir: `cmd`,
+			},
+			pos:  token.Position{Filename: flatFile, Line: 15},
+			want: true,
+		},
+		{
+			name: "backslash-joined moduleRel from filepath.Rel on Windows still matches",
+			d: Diff{
+				changes: map[FileName][]Change{
+					"service-a/cmd/main.go": {{StartLine: 10, EndLine: 20}},
+				},
+				moduleRel: `service-a\cmd`,
+			},
+			pos:  token.Position{Filename: flatFile, Line: 15},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/diff/parse.go
+++ b/internal/diff/parse.go
@@ -34,12 +34,21 @@ func NewWithCmd[T execCmd](cmdContext func(name string, args ...string) T, modul
 
 	log.Infoln("Gathering files diff...")
 
+	absModuleRoot, err := filepath.Abs(moduleRoot)
+	if err != nil {
+		return Diff{}, fmt.Errorf("failed to resolve module root: %w", err)
+	}
+
 	gitRootOut, err := cmdContext("git", "rev-parse", "--show-toplevel").CombinedOutput()
 	if err != nil {
 		return Diff{}, fmt.Errorf("failed to determine git root: %w", err)
 	}
 	gitRoot := strings.TrimSpace(string(gitRootOut))
-	moduleRel, _ := filepath.Rel(gitRoot, moduleRoot)
+
+	moduleRel, err := filepath.Rel(gitRoot, absModuleRoot)
+	if err != nil {
+		return Diff{}, fmt.Errorf("failed to determine module path relative to git root: %w", err)
+	}
 
 	cmd := cmdContext("git", "diff", "--merge-base", diffRef)
 

--- a/internal/diff/parse.go
+++ b/internal/diff/parse.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/bluekeyes/go-gitdiff/gitdiff"
 
@@ -12,8 +14,10 @@ import (
 )
 
 // New creates a new Diff by parsing git diff output using the default command executor.
-func New() (Diff, error) {
-	return NewWithCmd(exec.Command)
+// moduleRoot is the absolute path to the Go module root (mod.Root).
+// callingDir is the relative path from the module root to the CWD (mod.CallingDir).
+func New(moduleRoot, callingDir string) (Diff, error) {
+	return NewWithCmd(exec.Command, moduleRoot, callingDir)
 }
 
 type execCmd interface {
@@ -22,25 +26,32 @@ type execCmd interface {
 
 // NewWithCmd creates a new Diff by parsing git diff output using a custom command executor.
 // This is useful for testing.
-func NewWithCmd[T execCmd](cmdContext func(name string, args ...string) T) (Diff, error) {
+func NewWithCmd[T execCmd](cmdContext func(name string, args ...string) T, moduleRoot, callingDir string) (Diff, error) {
 	diffRef := configuration.Get[string](configuration.UnleashDiffRef)
 	if diffRef == "" {
-		return nil, nil
+		return Diff{}, nil
 	}
 
 	log.Infoln("Gathering files diff...")
+
+	gitRootOut, err := cmdContext("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		return Diff{}, fmt.Errorf("failed to determine git root: %w", err)
+	}
+	gitRoot := strings.TrimSpace(string(gitRootOut))
+	moduleRel, _ := filepath.Rel(gitRoot, moduleRoot)
 
 	cmd := cmdContext("git", "diff", "--merge-base", diffRef)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("an error occured while calling git diff: %w\n\n%s", err, out)
+		return Diff{}, fmt.Errorf("an error occured while calling git diff: %w\n\n%s", err, out)
 	}
 
 	files, _, err := gitdiff.Parse(bytes.NewReader(out))
 	if err != nil {
-		return nil, fmt.Errorf("an error occured while parsing diff: %w", err)
+		return Diff{}, fmt.Errorf("an error occured while parsing diff: %w", err)
 	}
 
-	return newDiff(files), nil
+	return newDiff(files, moduleRel, callingDir), nil
 }

--- a/internal/diff/parse_test.go
+++ b/internal/diff/parse_test.go
@@ -12,170 +12,166 @@ import (
 	"github.com/go-gremlins/gremlins/internal/configuration"
 )
 
-func TestNewWithCmd(t *testing.T) {
-	t.Run("must return zero Diff on empty flag", func(t *testing.T) {
-		m := &mock{}
+func TestNewWithCmd_EmptyDiffRef(t *testing.T) {
+	m := &mock{}
 
-		d, err := NewWithCmd(m.call, "/repo", "")
+	d, err := NewWithCmd(m.call, "/repo", "")
 
-		if !reflect.DeepEqual(d, Diff{}) || err != nil {
-			t.Fatal("incorrect result")
-		}
-	})
+	if !reflect.DeepEqual(d, Diff{}) || err != nil {
+		t.Fatal("incorrect result")
+	}
+}
 
-	t.Run("must return error on git rev-parse failure", func(t *testing.T) {
-		viper.Set(configuration.UnleashDiffRef, "main")
-
-		m := &mock{
-			responses: []mockResponse{
-				{err: errors.New("not a git repo")},
-			},
-		}
-
-		_, err := NewWithCmd(m.call, "/repo", "")
-		if err == nil {
-			t.Error("must return error")
-		}
-	})
-
-	t.Run("must return error on git diff failure", func(t *testing.T) {
-		viper.Set(configuration.UnleashDiffRef, "test")
-
-		m := &mock{
+func TestNewWithCmd_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses []mockResponse
+		wantCalls int
+		wantArgs  []string
+	}{
+		{
+			name:      "git rev-parse failure",
+			responses: []mockResponse{{err: errors.New("not a git repo")}},
+		},
+		{
+			name: "git diff failure",
 			responses: []mockResponse{
 				{output: []byte("/repo\n")},
 				{err: errors.New("test")},
 			},
-		}
-
-		_, err := NewWithCmd(m.call, "/repo", "")
-		if err == nil {
-			t.Error("must return error")
-		}
-
-		if len(m.calls) != 2 {
-			t.Fatal("expected 2 cmd calls")
-		}
-
-		expectedArgs := []string{"diff", "--merge-base", "test"}
-
-		if m.calls[1].name != "git" || !reflect.DeepEqual(m.calls[1].args, expectedArgs) {
-			t.Log("name", m.calls[1].name)
-			t.Log("args", m.calls[1].args)
-			t.Error("cmd not called properly")
-		}
-	})
-
-	t.Run("must return diff error", func(t *testing.T) {
-		viper.Set(configuration.UnleashDiffRef, "test")
-
-		m := &mock{
+			wantCalls: 2,
+			wantArgs:  []string{"diff", "--merge-base", "test"},
+		},
+		{
+			name: "diff parse error",
 			responses: []mockResponse{
 				{output: []byte("/repo\n")},
 				{output: []byte(testErrDiff)},
 			},
-		}
+		},
+	}
 
-		_, err := NewWithCmd(m.call, "/repo", "")
-		if err == nil {
-			t.Error("must return error")
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Set(configuration.UnleashDiffRef, "test")
+			defer viper.Reset()
 
-	t.Run("must return changes", func(t *testing.T) {
-		viper.Set(configuration.UnleashDiffRef, "test")
+			m := &mock{responses: tt.responses}
 
-		m := &mock{
-			responses: []mockResponse{
-				{output: []byte("/repo\n")},
-				{output: []byte(testDiff)},
-			},
-		}
+			_, err := NewWithCmd(m.call, "/repo", "")
+			if err == nil {
+				t.Error("must return error")
+			}
 
-		expected := Diff{
-			changes: map[FileName][]Change{
-				"test/test": {{StartLine: 44, EndLine: 44}},
-			},
-			moduleRel: ".",
-		}
+			if tt.wantCalls > 0 && len(m.calls) != tt.wantCalls {
+				t.Fatalf("expected %d cmd calls, got %d", tt.wantCalls, len(m.calls))
+			}
 
-		result, err := NewWithCmd(m.call, "/repo", "")
+			if tt.wantArgs != nil {
+				if m.calls[1].name != "git" || !reflect.DeepEqual(m.calls[1].args, tt.wantArgs) {
+					t.Errorf("cmd not called properly: name=%s args=%v", m.calls[1].name, m.calls[1].args)
+				}
+			}
+		})
+	}
+}
 
-		if err != nil || !reflect.DeepEqual(result, expected) {
-			t.Log("err", err)
-			t.Log("result", result)
-			t.Error("unexpected result")
-		}
-	})
+func TestNewWithCmd_FlatRepo(t *testing.T) {
+	viper.Set(configuration.UnleashDiffRef, "test")
+	defer viper.Reset()
 
-	t.Run("monorepo: moduleRel computed from git root", func(t *testing.T) {
-		viper.Set(configuration.UnleashDiffRef, "main")
+	m := &mock{
+		responses: []mockResponse{
+			{output: []byte("/repo\n")},
+			{output: []byte(testDiff)},
+		},
+	}
 
-		m := &mock{
-			responses: []mockResponse{
-				{output: []byte("/home/user/repo\n")},
-				{output: []byte(testMonorepoDiff)},
-			},
-		}
+	expected := Diff{
+		changes: map[FileName][]Change{
+			"test/test": {{StartLine: 44, EndLine: 44}},
+		},
+		moduleRel: ".",
+	}
 
-		expected := Diff{
-			changes: map[FileName][]Change{
-				"service-a/main.go": {{StartLine: 44, EndLine: 44}},
-			},
-			moduleRel: "service-a",
-		}
+	result, err := NewWithCmd(m.call, "/repo", "")
 
-		result, err := NewWithCmd(m.call, "/home/user/repo/service-a", "")
+	if err != nil || !reflect.DeepEqual(result, expected) {
+		t.Log("err", err)
+		t.Log("result", result)
+		t.Error("unexpected result")
+	}
+}
 
-		if err != nil || !reflect.DeepEqual(result, expected) {
-			t.Log("err", err)
-			t.Log("result", result)
-			t.Error("unexpected result")
-		}
-	})
+func TestNewWithCmd_Monorepo(t *testing.T) {
+	viper.Set(configuration.UnleashDiffRef, "main")
+	defer viper.Reset()
 
-	t.Run("monorepo: relative moduleRoot is resolved to absolute before computing moduleRel", func(t *testing.T) {
-		viper.Set(configuration.UnleashDiffRef, "main")
+	m := &mock{
+		responses: []mockResponse{
+			{output: []byte("/home/user/repo\n")},
+			{output: []byte(testMonorepoDiff)},
+		},
+	}
 
-		wd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() { _ = os.Chdir(wd) }()
+	expected := Diff{
+		changes: map[FileName][]Change{
+			"service-a/main.go": {{StartLine: 44, EndLine: 44}},
+		},
+		moduleRel: "service-a",
+	}
 
-		repoRoot, err := filepath.EvalSymlinks(t.TempDir())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.MkdirAll(filepath.Join(repoRoot, "service-a"), 0o750); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(repoRoot); err != nil {
-			t.Fatal(err)
-		}
+	result, err := NewWithCmd(m.call, "/home/user/repo/service-a", "")
 
-		m := &mock{
-			responses: []mockResponse{
-				{output: []byte(repoRoot + "\n")},
-				{output: []byte(testMonorepoDiff)},
-			},
-		}
+	if err != nil || !reflect.DeepEqual(result, expected) {
+		t.Log("err", err)
+		t.Log("result", result)
+		t.Error("unexpected result")
+	}
+}
 
-		expected := Diff{
-			changes: map[FileName][]Change{
-				"service-a/main.go": {{StartLine: 44, EndLine: 44}},
-			},
-			moduleRel: "service-a",
-		}
+func TestNewWithCmd_RelativeModuleRoot(t *testing.T) {
+	viper.Set(configuration.UnleashDiffRef, "main")
+	defer viper.Reset()
 
-		result, err := NewWithCmd(m.call, "service-a", "")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(wd) }()
 
-		if err != nil || !reflect.DeepEqual(result, expected) {
-			t.Log("err", err)
-			t.Log("result", result)
-			t.Error("unexpected result")
-		}
-	})
+	repoRoot, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, "service-a"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &mock{
+		responses: []mockResponse{
+			{output: []byte(repoRoot + "\n")},
+			{output: []byte(testMonorepoDiff)},
+		},
+	}
+
+	expected := Diff{
+		changes: map[FileName][]Change{
+			"service-a/main.go": {{StartLine: 44, EndLine: 44}},
+		},
+		moduleRel: "service-a",
+	}
+
+	result, err := NewWithCmd(m.call, "service-a", "")
+
+	if err != nil || !reflect.DeepEqual(result, expected) {
+		t.Log("err", err)
+		t.Log("result", result)
+		t.Error("unexpected result")
+	}
 }
 
 type mockResponse struct {

--- a/internal/diff/parse_test.go
+++ b/internal/diff/parse_test.go
@@ -2,6 +2,8 @@ package diff
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -124,6 +126,49 @@ func TestNewWithCmd(t *testing.T) {
 		}
 
 		result, err := NewWithCmd(m.call, "/home/user/repo/service-a", "")
+
+		if err != nil || !reflect.DeepEqual(result, expected) {
+			t.Log("err", err)
+			t.Log("result", result)
+			t.Error("unexpected result")
+		}
+	})
+
+	t.Run("monorepo: relative moduleRoot is resolved to absolute before computing moduleRel", func(t *testing.T) {
+		viper.Set(configuration.UnleashDiffRef, "main")
+
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Chdir(wd) }()
+
+		repoRoot, err := filepath.EvalSymlinks(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(repoRoot, "service-a"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(repoRoot); err != nil {
+			t.Fatal(err)
+		}
+
+		m := &mock{
+			responses: []mockResponse{
+				{output: []byte(repoRoot + "\n")},
+				{output: []byte(testMonorepoDiff)},
+			},
+		}
+
+		expected := Diff{
+			changes: map[FileName][]Change{
+				"service-a/main.go": {{StartLine: 44, EndLine: 44}},
+			},
+			moduleRel: "service-a",
+		}
+
+		result, err := NewWithCmd(m.call, "service-a", "")
 
 		if err != nil || !reflect.DeepEqual(result, expected) {
 			t.Log("err", err)

--- a/internal/diff/parse_test.go
+++ b/internal/diff/parse_test.go
@@ -11,37 +11,55 @@ import (
 )
 
 func TestNewWithCmd(t *testing.T) {
-	t.Run("must return nil on empty flag", func(t *testing.T) {
+	t.Run("must return zero Diff on empty flag", func(t *testing.T) {
 		m := &mock{}
 
-		d, err := NewWithCmd(m.call)
+		d, err := NewWithCmd(m.call, "/repo", "")
 
-		if d != nil && err != nil {
+		if !reflect.DeepEqual(d, Diff{}) || err != nil {
 			t.Fatal("incorrect result")
 		}
 	})
 
-	t.Run("must return error", func(t *testing.T) {
+	t.Run("must return error on git rev-parse failure", func(t *testing.T) {
+		viper.Set(configuration.UnleashDiffRef, "main")
+
+		m := &mock{
+			responses: []mockResponse{
+				{err: errors.New("not a git repo")},
+			},
+		}
+
+		_, err := NewWithCmd(m.call, "/repo", "")
+		if err == nil {
+			t.Error("must return error")
+		}
+	})
+
+	t.Run("must return error on git diff failure", func(t *testing.T) {
 		viper.Set(configuration.UnleashDiffRef, "test")
 
 		m := &mock{
-			outputErr: errors.New("test"),
+			responses: []mockResponse{
+				{output: []byte("/repo\n")},
+				{err: errors.New("test")},
+			},
 		}
 
-		_, err := NewWithCmd(m.call)
+		_, err := NewWithCmd(m.call, "/repo", "")
 		if err == nil {
 			t.Error("must return error")
 		}
 
-		if m.calls != 1 {
-			t.Fatal("cmd not called")
+		if len(m.calls) != 2 {
+			t.Fatal("expected 2 cmd calls")
 		}
 
 		expectedArgs := []string{"diff", "--merge-base", "test"}
 
-		if m.callName != "git" || !reflect.DeepEqual(m.callArgs, expectedArgs) {
-			t.Log("name", m.callName)
-			t.Log("args", m.callArgs)
+		if m.calls[1].name != "git" || !reflect.DeepEqual(m.calls[1].args, expectedArgs) {
+			t.Log("name", m.calls[1].name)
+			t.Log("args", m.calls[1].args)
 			t.Error("cmd not called properly")
 		}
 	})
@@ -50,10 +68,13 @@ func TestNewWithCmd(t *testing.T) {
 		viper.Set(configuration.UnleashDiffRef, "test")
 
 		m := &mock{
-			output: []byte(testErrDiff),
+			responses: []mockResponse{
+				{output: []byte("/repo\n")},
+				{output: []byte(testErrDiff)},
+			},
 		}
 
-		_, err := NewWithCmd(m.call)
+		_, err := NewWithCmd(m.call, "/repo", "")
 		if err == nil {
 			t.Error("must return error")
 		}
@@ -63,14 +84,46 @@ func TestNewWithCmd(t *testing.T) {
 		viper.Set(configuration.UnleashDiffRef, "test")
 
 		m := &mock{
-			output: []byte(testDiff),
+			responses: []mockResponse{
+				{output: []byte("/repo\n")},
+				{output: []byte(testDiff)},
+			},
 		}
 
 		expected := Diff{
-			"test/test": {{StartLine: 44, EndLine: 44}},
+			changes: map[FileName][]Change{
+				"test/test": {{StartLine: 44, EndLine: 44}},
+			},
+			moduleRel: ".",
 		}
 
-		result, err := NewWithCmd(m.call)
+		result, err := NewWithCmd(m.call, "/repo", "")
+
+		if err != nil || !reflect.DeepEqual(result, expected) {
+			t.Log("err", err)
+			t.Log("result", result)
+			t.Error("unexpected result")
+		}
+	})
+
+	t.Run("monorepo: moduleRel computed from git root", func(t *testing.T) {
+		viper.Set(configuration.UnleashDiffRef, "main")
+
+		m := &mock{
+			responses: []mockResponse{
+				{output: []byte("/home/user/repo\n")},
+				{output: []byte(testMonorepoDiff)},
+			},
+		}
+
+		expected := Diff{
+			changes: map[FileName][]Change{
+				"service-a/main.go": {{StartLine: 44, EndLine: 44}},
+			},
+			moduleRel: "service-a",
+		}
+
+		result, err := NewWithCmd(m.call, "/home/user/repo/service-a", "")
 
 		if err != nil || !reflect.DeepEqual(result, expected) {
 			t.Log("err", err)
@@ -80,24 +133,36 @@ func TestNewWithCmd(t *testing.T) {
 	})
 }
 
+type mockResponse struct {
+	output []byte
+	err    error
+}
+
+type mockCall struct {
+	name string
+	args []string
+}
+
 type mock struct {
-	calls     int
-	callName  string
-	callArgs  []string
-	output    []byte
-	outputErr error
+	calls     []mockCall
+	responses []mockResponse
+	idx       int
 }
 
 func (m *mock) call(name string, args ...string) execCmd {
-	m.calls++
-	m.callName = name
-	m.callArgs = args
+	m.calls = append(m.calls, mockCall{name: name, args: args})
 
 	return m
 }
 
 func (m *mock) CombinedOutput() ([]byte, error) {
-	return m.output, m.outputErr
+	if m.idx >= len(m.responses) {
+		return nil, nil
+	}
+	resp := m.responses[m.idx]
+	m.idx++
+
+	return resp.output, resp.err
 }
 
 const (
@@ -107,12 +172,12 @@ index 54051bc..b92c425 100644
 --- a/test/test
 +++ b/test/test
 @@ -41,6 +41,7 @@ const (
- 	test = "test"
- 	test = "test"
- 	test = "test"
-+	test = "test"
- 	test = "test"
- 	test = "test"
+ test = "test"
+ test = "test"
+ test = "test"
++test = "test"
+ test = "test"
+ test = "test"
  )
 `
 	testErrDiff = `
@@ -121,9 +186,23 @@ index 54051bc..b92c425 100644
 --- a/test/test
 +++ b/test/test
 @@ -41,7 +41,7 @@ const (
- 	test = "test"
-+	test = "test"
- 	test = "test"
+ test = "test"
++test = "test"
+ test = "test"
+ )
+`
+	testMonorepoDiff = `
+diff --git a/service-a/main.go b/service-a/main.go
+index 54051bc..b92c425 100644
+--- a/service-a/main.go
++++ b/service-a/main.go
+@@ -41,6 +41,7 @@ const (
+ test = "test"
+ test = "test"
+ test = "test"
++test = "test"
+ test = "test"
+ test = "test"
  )
 `
 )

--- a/internal/diff/parse_test.go
+++ b/internal/diff/parse_test.go
@@ -147,7 +147,7 @@ func TestNewWithCmd(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(filepath.Join(repoRoot, "service-a"), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Join(repoRoot, "service-a"), 0o750); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.Chdir(repoRoot); err != nil {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -632,9 +632,9 @@ func TestSkipNotDiffMutants(t *testing.T) {
 	viperSet(map[string]any{configuration.UnleashDryRunKey: true})
 	defer viperReset()
 
-	codeData := engine.CodeData{Diff: diff.Diff{
+	codeData := engine.CodeData{Diff: diff.FromChanges(map[diff.FileName][]diff.Change{
 		"file.go": nil,
-	}}
+	})}
 	mut := engine.New(mod, codeData, newJobDealerStub(t), engine.WithDirFs(sys))
 	res := mut.Run(context.Background())
 
@@ -645,6 +645,72 @@ func TestSkipNotDiffMutants(t *testing.T) {
 	for _, mutant := range res.Mutants {
 		if mutant.Status() != mutator.Skipped {
 			t.Errorf("all mutants should be skipped")
+		}
+	}
+}
+
+func TestSkipNotDiffMutants_Monorepo(t *testing.T) {
+	t.Parallel()
+	f, _ := os.Open("testdata/fixtures/geq_go")
+	file, _ := io.ReadAll(f)
+
+	sys := fstest.MapFS{
+		"main.go": {Data: file},
+	}
+	mod := gomodule.GoModule{
+		Name:       "example.com",
+		Root:       ".",
+		CallingDir: ".",
+	}
+	viperSet(map[string]any{configuration.UnleashDryRunKey: true})
+	defer viperReset()
+
+	codeData := engine.CodeData{Diff: diff.FromChanges(map[diff.FileName][]diff.Change{
+		"service-a/main.go": nil,
+	}).WithModuleRel("service-a")}
+	mut := engine.New(mod, codeData, newJobDealerStub(t), engine.WithDirFs(sys))
+	res := mut.Run(context.Background())
+
+	if got := res.Mutants; len(got) == 0 {
+		t.Errorf("should receive mutants")
+	}
+
+	for _, mutant := range res.Mutants {
+		if mutant.Status() != mutator.Skipped {
+			t.Errorf("all mutants should be skipped in monorepo mode")
+		}
+	}
+}
+
+func TestSkipNotDiffMutants_Monorepo_Match(t *testing.T) {
+	t.Parallel()
+	f, _ := os.Open("testdata/fixtures/geq_go")
+	file, _ := io.ReadAll(f)
+
+	sys := fstest.MapFS{
+		"main.go": {Data: file},
+	}
+	mod := gomodule.GoModule{
+		Name:       "example.com",
+		Root:       ".",
+		CallingDir: ".",
+	}
+	viperSet(map[string]any{configuration.UnleashDryRunKey: true})
+	defer viperReset()
+
+	codeData := engine.CodeData{Diff: diff.FromChanges(map[diff.FileName][]diff.Change{
+		"service-a/main.go": {{StartLine: 1, EndLine: 100}},
+	}).WithModuleRel("service-a")}
+	mut := engine.New(mod, codeData, newJobDealerStub(t), engine.WithDirFs(sys))
+	res := mut.Run(context.Background())
+
+	if got := res.Mutants; len(got) == 0 {
+		t.Errorf("should receive mutants")
+	}
+
+	for _, mutant := range res.Mutants {
+		if mutant.Status() == mutator.Skipped {
+			t.Errorf("mutants in changed monorepo file should not be skipped, got %v", mutant.Status())
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

In a monorepo with multiple Go modules, `--diff` silently skips all mutants because of a path mismatch: `git diff --merge-base` produces git-root-relative paths (e.g. `service-a/main.go`) while `token.Position.Filename` is module-root-relative (e.g. `main.go`). The `IsChanged()` lookup did a direct map key comparison with zero path normalization, so keys never matched.

This fix converts `Diff` from a map type to a struct that carries `moduleRel` and `callingDir` path info. `IsChanged()` now prepends `filepath.Join(moduleRel, callingDir, pos.Filename)` before the lookup. The relative path from git root to module root is computed at diff-parse time via `git rev-parse --show-toplevel`.

Fixes #296

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The coverage module (`internal/coverage/coverage.go`) already normalizes paths with `filepath.Rel()` in `removeModuleFromPath` — the diff module simply lacked an equivalent step. This fix uses the prepend approach (rather than prefix stripping) to avoid ambiguity when multiple modules in the monorepo have files with the same name (e.g. two `main.go` files).