### PR TITLE
engine: run mutants Go coverage cannot map

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -32,7 +32,7 @@ catch their damage?
 ## Features
 
 - Discovers mutant candidates and tests them
-- Only tests mutants covered by tests
+- Tests covered mutants plus constants and conditions for covered switch cases
 - Can test mutants only in PR changes
 - Supports five mutant types
 - Yaml-based configuration

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -8,8 +8,9 @@ $ gremlins unleash #(1)
 
 1. If `unleash` is too long to type for you, you can use `run` or `r` which will do the same.
 
-Gremlins only tests mutations of parts of the code already covered by test cases. If a mutant is not covered, why bother
-testing? You already know it will not be caught. In any case, Gremlins will report which mutations aren't covered.
+Gremlins uses Go's coverage profile to avoid testing mutations in code that the test suite does not execute. It also
+tests mutations in constant declarations, which Go coverage cannot instrument, and switch case conditions whose case
+body is covered. Gremlins reports the remaining mutations as not covered.
 
 Gremlins will report each mutation as:
 

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -85,8 +85,11 @@ gremlins unleash -E "_(gen|wrap).go$" -E "^(generate|wrap)/" -E "internal/super_
 :material-flag: `--diff`/`-D` · :material-sign-direction: Default: empty
 
 Run tests only for mutants inside code changes between current state and git reference (branch or commit).
-By default, Gremlins tests each mutant covered by tests, each constant mutant, and each switch case condition whose body
-is covered.
+By default, Gremlins tests:
+
+- each mutant covered by tests;
+- each constant mutant;
+- each switch case condition whose body is covered.
 
 #### Branch merge base
 

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -85,7 +85,8 @@ gremlins unleash -E "_(gen|wrap).go$" -E "^(generate|wrap)/" -E "internal/super_
 :material-flag: `--diff`/`-D` · :material-sign-direction: Default: empty
 
 Run tests only for mutants inside code changes between current state and git reference (branch or commit).
-The default is each mutant covered by tests.
+By default, Gremlins tests each mutant covered by tests, each constant mutant, and each switch case condition whose body
+is covered.
 
 #### Branch merge base
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -126,18 +126,25 @@ func (mu *Engine) runOnFile(fileName string) {
 	file, _ := parser.ParseFile(set, fileName, src, parser.ParseComments)
 	_ = src.Close()
 
+	var parents []ast.Node
 	ast.Inspect(file, func(node ast.Node) bool {
-		n, ok := NewTokenNode(node)
-		if !ok {
+		if node == nil {
+			parents = parents[:len(parents)-1]
+
 			return true
 		}
-		mu.findMutations(fileName, set, file, n)
+
+		n, ok := NewTokenNode(node)
+		if ok {
+			mu.findMutations(fileName, set, file, n, parents)
+		}
+		parents = append(parents, node)
 
 		return true
 	})
 }
 
-func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.File, node *NodeToken) {
+func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.File, node *NodeToken, parents []ast.Node) {
 	mutantTypes, ok := TokenMutantType[node.Tok()]
 	if !ok {
 		return
@@ -151,7 +158,7 @@ func (mu *Engine) findMutations(fileName string, set *token.FileSet, file *ast.F
 		mutantType := mt
 		tm := NewTokenMutant(pkg, set, file, node)
 		tm.SetType(mutantType)
-		tm.SetStatus(mu.mutationStatus(set.Position(node.TokPos)))
+		tm.SetStatus(mu.mutationStatus(set, node.TokPos, parents))
 
 		mu.mutantStream <- tm
 	}
@@ -185,18 +192,42 @@ func normalisePkgPath(pkg string) string {
 	return strings.ReplaceAll(pkg, sep, "/")
 }
 
-func (mu *Engine) mutationStatus(pos token.Position) mutator.Status {
+func (mu *Engine) mutationStatus(set *token.FileSet, pos token.Pos, parents []ast.Node) mutator.Status {
 	var status mutator.Status
+	position := set.Position(pos)
 
-	if mu.codeData.Cov.IsCovered(pos) {
+	if mu.codeData.Cov.IsCovered(position) || mu.isRunnableBySyntax(set, pos, parents) {
 		status = mutator.Runnable
 	}
 
-	if !mu.codeData.Diff.IsChanged(pos) {
+	if !mu.codeData.Diff.IsChanged(position) {
 		status = mutator.Skipped
 	}
 
 	return status
+}
+
+func (mu *Engine) isRunnableBySyntax(set *token.FileSet, pos token.Pos, parents []ast.Node) bool {
+	for i := len(parents) - 1; i >= 0; i-- {
+		switch parent := parents[i].(type) {
+		case *ast.GenDecl:
+			return parent.Tok == token.CONST
+		case *ast.CaseClause:
+			if pos >= parent.Colon {
+				return false
+			}
+
+			for _, statement := range parent.Body {
+				if mu.codeData.Cov.IsCovered(set.Position(statement.Pos())) {
+					return true
+				}
+			}
+
+			return false
+		}
+	}
+
+	return false
 }
 
 func (mu *Engine) executeTests(ctx context.Context) report.Results {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -53,6 +53,13 @@ func notCoveredPosition(fixture string) coverage.Result {
 	return coverage.Result{Profile: p, Elapsed: 10}
 }
 
+func coveredSwitchCaseBody(fixture string) coverage.Result {
+	fn := filenameFromFixture(fixture)
+	p := coverage.Profile{fn: {{StartLine: 5, EndLine: 6, StartCol: 26, EndCol: 11}}}
+
+	return coverage.Result{Profile: p, Elapsed: 10}
+}
+
 type mutationsTest struct {
 	name       string
 	fixture    string
@@ -60,6 +67,7 @@ type mutationsTest struct {
 	mutantType mutator.Type
 	token      token.Token
 	mutStatus  mutator.Status
+	line       int
 }
 
 var mutationsTests = []mutationsTest{
@@ -489,6 +497,32 @@ var mutationsTests = []mutationsTest{
 		token:      token.ILLEGAL,
 		covResult:  notCoveredPosition("testdata/fixtures/illegal_go"),
 	},
+	{
+		name:       "it runs mutations in constant expressions without direct coverage",
+		fixture:    "testdata/fixtures/const_add_go",
+		mutantType: mutator.ArithmeticBase,
+		token:      token.ADD,
+		mutStatus:  mutator.Runnable,
+		line:       3,
+	},
+	{
+		name:       "it runs mutations in predicates whose switch case body is covered",
+		fixture:    "testdata/fixtures/switch_cases_go",
+		mutantType: mutator.ConditionalsNegation,
+		token:      token.EQL,
+		covResult:  coveredSwitchCaseBody("testdata/fixtures/switch_cases_go"),
+		mutStatus:  mutator.Runnable,
+		line:       5,
+	},
+	{
+		name:       "it leaves predicates uncovered when their switch case body is uncovered",
+		fixture:    "testdata/fixtures/switch_cases_go",
+		mutantType: mutator.ConditionalsNegation,
+		token:      token.EQL,
+		covResult:  coveredSwitchCaseBody("testdata/fixtures/switch_cases_go"),
+		mutStatus:  mutator.NotCovered,
+		line:       7,
+	},
 }
 
 func TestMutations(t *testing.T) {
@@ -520,7 +554,8 @@ func TestMutations(t *testing.T) {
 			}
 
 			for _, g := range got {
-				if g.Type() == tc.mutantType && g.Status() == tc.mutStatus && g.Pos() > 0 {
+				lineMatches := tc.line == 0 || g.Position().Line == tc.line
+				if g.Type() == tc.mutantType && g.Status() == tc.mutStatus && g.Pos() > 0 && lineMatches {
 					// PASS
 					return
 				}

--- a/internal/engine/testdata/fixtures/const_add_go
+++ b/internal/engine/testdata/fixtures/const_add_go
@@ -1,0 +1,3 @@
+package main
+
+const timeout = 10 + 5

--- a/internal/engine/testdata/fixtures/switch_cases_go
+++ b/internal/engine/testdata/fixtures/switch_cases_go
@@ -1,0 +1,12 @@
+package main
+
+func classify(value string) int {
+	switch {
+	case value == "covered":
+		return 1
+	case value == "uncovered":
+		return 2
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
## Proposed changes

Go does not assign coverage counters to constant expressions or switch case conditions. Gremlins checks each mutant token against the coverage profile, so it reports these mutants as `NOT COVERED` and never tests them even when the suite exercises their observable behavior.

This change keeps the existing exact-position check and adds two narrow AST-aware rules:

- constant-expression mutants are runnable because Go cannot provide direct coverage for them;
- a switch case condition is runnable when a statement in that same case body is covered.

Conditions for uncovered case bodies remain `NOT COVERED`, and diff-based filtering still takes precedence. Regression fixtures cover all three outcomes. The user documentation now describes these exceptions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

An end-to-end run against Kargo's MCP package demonstrates the effect on real compound switch conditions and constants:

- before: 509 killed, 35 not covered;
- after: 543 killed, 1 not covered.

All 34 newly runnable mutants were killed. The remaining uncovered mutant is a genuinely unreachable defensive error path.
