### PR TITLE
feat(coverage): accept a pre-computed coverage profile

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -50,6 +50,8 @@ const (
 	paramDiff               = "diff"
 	paramBuildTags          = "tags"
 	paramCoverPackages      = "coverpkg"
+	paramCoverageProfile    = "coverage-profile"
+	paramCoverageElapsed    = "coverage-elapsed"
 	paramDryRun             = "dry-run"
 	paramOutputStatuses     = "output-statuses"
 	paramOutputDiffStatuses = "output-diff-statuses"
@@ -211,6 +213,8 @@ func setFlagsOnCmd(cmd *cobra.Command) error {
 		{Name: paramOutputDiffStatuses, CfgKey: configuration.UnleashOutputDiffStatusesKey, DefaultV: "", Usage: "print diff for mutants with these statuses, allowed values - 'lk'"},
 		{Name: paramBuildTags, CfgKey: configuration.UnleashTagsKey, Shorthand: "t", DefaultV: "", Usage: "a comma-separated list of build tags"},
 		{Name: paramCoverPackages, CfgKey: configuration.UnleashCoverPkgKey, DefaultV: "", Usage: "a comma-separated list of package patterns"},
+		{Name: paramCoverageProfile, CfgKey: configuration.UnleashCoverageProfileKey, DefaultV: "", Usage: "reuse a pre-computed coverage profile instead of gathering coverage (requires --coverage-elapsed)"},
+		{Name: paramCoverageElapsed, CfgKey: configuration.UnleashCoverageElapsedKey, DefaultV: "", Usage: "how long the test run that produced --coverage-profile took, e.g. '2m42s'"},
 		{Name: paramDiff, CfgKey: configuration.UnleashDiffRef, Shorthand: "D", DefaultV: "", Usage: "diff branch or commit"},
 		{Name: paramOutput, CfgKey: configuration.UnleashOutputKey, Shorthand: "o", DefaultV: "", Usage: "set the output file for machine readable results"},
 		{Name: paramIntegrationMode, CfgKey: configuration.UnleashIntegrationMode, Shorthand: "i", DefaultV: false, Usage: "makes Gremlins run the complete test suite for each mutation"},

--- a/cmd/unleash_test.go
+++ b/cmd/unleash_test.go
@@ -61,6 +61,16 @@ func TestUnleash(t *testing.T) {
 			defValue: "true",
 		},
 		{
+			name:     "coverage-elapsed",
+			flagType: "string",
+			defValue: "",
+		},
+		{
+			name:     "coverage-profile",
+			flagType: "string",
+			defValue: "",
+		},
+		{
 			name:     "coverpkg",
 			flagType: "string",
 			defValue: "",

--- a/docs/docs/schema/configuration.json
+++ b/docs/docs/schema/configuration.json
@@ -37,6 +37,24 @@
             "./internal/log,./pkg/..."
           ]
         },
+        "coverage-profile": {
+          "title": "Coverage profile",
+          "description": "Reuse a pre-computed coverage profile instead of gathering coverage",
+          "type": "string",
+          "default": "",
+          "examples": [
+            "coverage.out"
+          ]
+        },
+        "coverage-elapsed": {
+          "title": "Coverage elapsed",
+          "description": "How long the test run that produced the coverage profile took",
+          "type": "string",
+          "default": "",
+          "examples": [
+            "2m42s"
+          ]
+        },
         "output": {
           "title": "Output",
           "description": "The output file for machine readable results",

--- a/docs/docs/usage/commands/unleash/index.md
+++ b/docs/docs/usage/commands/unleash/index.md
@@ -60,6 +60,46 @@ The default is for each test to analyze only the package being tested.
 gremlins unleash --coverpkg "./internal/...,./pkg/..."
 ```
 
+### Coverage profile
+
+:material-flag: `--coverage-profile` · :material-sign-direction: Default: empty
+
+Reuses a pre-computed Go coverage profile instead of gathering coverage.
+
+Gremlins normally starts by running the whole test suite to find out which code
+is covered, since there is no point mutating code no test exercises. A caller
+that has just run that suite itself — a CI pipeline with its own coverage gate,
+for instance — is paying for it twice, and on a large suite the coverage run can
+cost more than the mutation testing that follows it.
+
+The profile must describe the current state of the source, so it is up to the
+caller to be sure it is fresh: Gremlins reads it as given. A stale profile
+silently mutates the wrong lines.
+
+Requires `--coverage-elapsed`.
+
+```shell
+go test ./... -coverprofile coverage.out -count=1
+gremlins unleash --coverage-profile coverage.out --coverage-elapsed 2m42s
+```
+
+### Coverage elapsed
+
+:material-flag: `--coverage-elapsed` · :material-sign-direction: Default: empty
+
+How long the test run that produced `--coverage-profile` took.
+
+Gremlins derives the per-mutant timeout from the duration of the coverage run
+(see [Timeout coefficient](#timeout-coefficient)), which it cannot measure when
+it did not perform that run. Supplying a duration far below the real one makes
+mutants that the tests do in fact kill get reported as `TIMED OUT` instead.
+
+The value is any Go duration string.
+
+```shell
+gremlins unleash --coverage-profile coverage.out --coverage-elapsed 90s
+```
+
 ### Exclude files
 
 :material-flag: `--exclude-files/-E` · :material-sign-direction: Default: empty

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -39,6 +39,8 @@ const (
 	UnleashOutputKey             = "unleash.output"
 	UnleashTagsKey               = "unleash.tags"
 	UnleashCoverPkgKey           = "unleash.coverpkg"
+	UnleashCoverageProfileKey    = "unleash.coverage-profile"
+	UnleashCoverageElapsedKey    = "unleash.coverage-elapsed"
 	UnleashWorkersKey            = "unleash.workers"
 	UnleashTestCPUKey            = "unleash.test-cpu"
 	UnleashTimeoutCoefficientKey = "unleash.timeout-coefficient"

--- a/internal/coverage/coverage.go
+++ b/internal/coverage/coverage.go
@@ -53,6 +53,12 @@ type Coverage struct {
 	buildTags       string
 	coverPkg        string
 	integrationMode bool
+
+	// When profilePath is set, Run parses that pre-computed profile instead
+	// of gathering coverage itself, and reports profileElapsed as the test
+	// suite duration.
+	profilePath    string
+	profileElapsed string
 }
 
 // Option for the Coverage initialization.
@@ -71,6 +77,8 @@ func NewWithCmd(cmdContext execContext, workdir string, mod gomodule.GoModule, o
 	buildTags := configuration.Get[string](configuration.UnleashTagsKey)
 	coverPkg := configuration.Get[string](configuration.UnleashCoverPkgKey)
 	integrationMode := configuration.Get[bool](configuration.UnleashIntegrationMode)
+	profilePath := configuration.Get[string](configuration.UnleashCoverageProfileKey)
+	profileElapsed := configuration.Get[string](configuration.UnleashCoverageElapsedKey)
 
 	c := &Coverage{
 		cmdContext:      cmdContext,
@@ -81,6 +89,8 @@ func NewWithCmd(cmdContext execContext, workdir string, mod gomodule.GoModule, o
 		buildTags:       buildTags,
 		coverPkg:        coverPkg,
 		integrationMode: integrationMode,
+		profilePath:     profilePath,
+		profileElapsed:  profileElapsed,
 	}
 	for _, opt := range opts {
 		c = opt(c)
@@ -95,6 +105,9 @@ func NewWithCmd(cmdContext execContext, workdir string, mod gomodule.GoModule, o
 // This is done to avoid that the download phase impacts the execution time which
 // is later used as timeout for the mutant testing execution.
 func (c *Coverage) Run() (Result, error) {
+	if c.profilePath != "" {
+		return c.runFromProfile()
+	}
 	log.Infof("Gathering coverage... ")
 	_ = os.Chdir(c.mod.Root)
 	if err := c.downloadModules(); err != nil {
@@ -113,8 +126,57 @@ func (c *Coverage) Run() (Result, error) {
 	return Result{Profile: profile, Elapsed: elapsed}, nil
 }
 
+// runFromProfile parses a pre-computed coverage profile instead of gathering
+// one. Gathering coverage means running the whole test suite, which a caller
+// that has just run it themselves would be paying for twice.
+//
+// The elapsed time cannot be measured in this mode, so the caller must supply
+// the duration of the run that produced the profile: it is the baseline for
+// the per-mutant timeout, and guessing it low turns KILLED mutants into
+// spurious TIMED OUT ones.
+func (c *Coverage) runFromProfile() (Result, error) {
+	elapsed, err := time.ParseDuration(c.profileElapsed)
+	if err != nil {
+		return Result{}, fmt.Errorf("coverage profile %q needs the duration of the test run that produced it: %w",
+			c.profilePath, err)
+	}
+	if elapsed <= 0 {
+		return Result{}, fmt.Errorf("coverage profile %q needs a positive duration for the test run that produced it, got %s",
+			c.profilePath, elapsed)
+	}
+
+	// Resolved before the chdir below, so a relative path is relative to the
+	// directory Gremlins was invoked from rather than the module root.
+	path, err := filepath.Abs(c.profilePath)
+	if err != nil {
+		return Result{}, fmt.Errorf("impossible to resolve the coverage profile path: %w", err)
+	}
+
+	log.Infof("Reusing coverage profile %s (test run took %s)\n", c.profilePath, elapsed)
+	_ = os.Chdir(c.mod.Root)
+	// Still needed: the profile spares us the coverage run, not the mutant
+	// test runs, which build against the module dependencies.
+	if err := c.downloadModules(); err != nil {
+		return Result{}, fmt.Errorf("impossible to download modules: %w", err)
+	}
+
+	profile, err := c.profileFrom(path)
+	if err != nil {
+		return Result{}, fmt.Errorf("an error occurred while reading coverage profile %q: %w", c.profilePath, err)
+	}
+
+	return Result{Profile: profile, Elapsed: elapsed}, nil
+}
+
 func (c *Coverage) profile() (Profile, error) {
-	cf, err := os.Open(c.filePath())
+	return c.profileFrom(c.filePath())
+}
+
+func (c *Coverage) profileFrom(path string) (Profile, error) {
+	// The path is the one the caller named on --profile, or the profile Gremlins
+	// just wrote itself. Opening the file the user asked for is the feature.
+	//nolint:gosec // G304: the profile path comes from configuration, not from input
+	cf, err := os.Open(path)
 	defer func(cf *os.File) {
 		_ = cf.Close()
 	}(cf)

--- a/internal/coverage/coverage_test.go
+++ b/internal/coverage/coverage_test.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/viper"
@@ -238,4 +239,92 @@ func fakeExecCommandFailure(run int) execContext {
 
 		return cmd
 	}
+}
+
+func TestCoverageReusesProvidedProfile(t *testing.T) {
+	viper.Set(configuration.UnleashCoverageProfileKey, "testdata/valid/coverage")
+	viper.Set(configuration.UnleashCoverageElapsedKey, "2m42s")
+	defer viper.Reset()
+
+	holder := &commandHolder{}
+	mod := gomodule.GoModule{
+		Name:       "example.com",
+		Root:       ".",
+		CallingDir: "path",
+	}
+	cov := coverage.NewWithCmd(fakeExecCommandSuccess(holder), "workdir", mod)
+
+	got, err := cov.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := coverage.Profile{
+		"file1.go": {
+			{StartLine: 47, StartCol: 2, EndLine: 48, EndCol: 16},
+		},
+		"file2.go": {
+			{StartLine: 52, StartCol: 2, EndLine: 53, EndCol: 16},
+		},
+	}
+	if !cmp.Equal(got.Profile, want) {
+		t.Error(cmp.Diff(got.Profile, want))
+	}
+	if wantElapsed := 2*time.Minute + 42*time.Second; got.Elapsed != wantElapsed {
+		t.Errorf("expected elapsed %v, got %v", wantElapsed, got.Elapsed)
+	}
+
+	// The whole point of the flag: the test suite must not be run again. Only
+	// the module download survives, since the mutant test runs still need it.
+	if len(holder.events) != 1 {
+		t.Fatalf("expected only 'go mod download' to be executed, got %d commands", len(holder.events))
+	}
+	if gotCmd := strings.Join(holder.events[0].args, " "); gotCmd != "mod download" {
+		t.Errorf("expected 'go mod download', got 'go %s'", gotCmd)
+	}
+}
+
+func TestCoverageProvidedProfileFails(t *testing.T) {
+	testCases := []struct {
+		name    string
+		profile string
+		elapsed string
+	}{
+		{name: "elapsed not set", profile: "testdata/valid/coverage", elapsed: ""},
+		{name: "elapsed not a duration", profile: "testdata/valid/coverage", elapsed: "ages"},
+		{name: "elapsed not positive", profile: "testdata/valid/coverage", elapsed: "0s"},
+		{name: "profile does not exist", profile: "testdata/valid/not-there", elapsed: "1s"},
+		{name: "profile not parseable", profile: "testdata/invalid/coverage", elapsed: "1s"},
+	}
+	mod := gomodule.GoModule{
+		Name:       "example.com",
+		Root:       ".",
+		CallingDir: "path",
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Set(configuration.UnleashCoverageProfileKey, tc.profile)
+			viper.Set(configuration.UnleashCoverageElapsedKey, tc.elapsed)
+			defer viper.Reset()
+
+			cov := coverage.NewWithCmd(fakeExecCommandSuccess(nil), "workdir", mod)
+
+			if _, err := cov.Run(); err == nil {
+				t.Error("expected run to report an error")
+			}
+		})
+	}
+
+	t.Run("go mod download fails", func(t *testing.T) {
+		viper.Set(configuration.UnleashCoverageProfileKey, "testdata/valid/coverage")
+		viper.Set(configuration.UnleashCoverageElapsedKey, "1s")
+		defer viper.Reset()
+
+		cov := coverage.NewWithCmd(fakeExecCommandFailure(0), "workdir", mod)
+
+		if _, err := cov.Run(); err == nil {
+			t.Error("expected run to report an error")
+		}
+	})
 }


### PR DESCRIPTION
## Proposed changes

Adds `--coverage-profile`, which reuses a pre-computed Go coverage profile instead of gathering coverage, and `--coverage-elapsed`, which supplies the duration of the run that produced it.

Gremlins begins every run by running the whole test suite to find out which code is covered. That is unavoidable when Gremlins is the only thing running the suite, and pure waste when the caller has just run it — a CI pipeline that enforces its own coverage gate and then runs a mutation gate on the same tree runs the same suite twice, back to back.

On a suite with real infrastructure behind it the coverage run is not the cheap half. Measured on a diff-scoped run of a Go service whose repository tests use containerised Postgres:

```
Gathering coverage... done in 2m42s
Mutation testing completed in 2 minutes 10 seconds
```

More than half the wall clock, spent recomputing a profile that was already on disk.

```shell
go test ./... -coverprofile coverage.out -count=1
gremlins unleash --coverage-profile coverage.out --coverage-elapsed 2m42s
```

Two decisions worth flagging for review:

**`--coverage-elapsed` is required and has no default.** The coverage run's duration is the baseline for the per-mutant timeout, and it is not observable when Gremlins did not perform the run. Defaulting it would mean guessing, and guessing low reports mutants the tests genuinely kill as `TIMED OUT` — which is #267 arriving through a different door. A missing, unparseable or non-positive duration is an error rather than a fallback. I would rather ask the caller, who knows, than invent a number, but I am happy to change the shape if you would prefer a single flag.

**Freshness is the caller's responsibility,** and the docs say so plainly. Gremlins cannot distinguish a current profile from one produced three commits ago, and a stale one silently mutates the wrong lines. The mechanism that pairs with the flag is a caller that regenerates the profile, or fingerprints the tree it describes, immediately before passing it.

Module download still runs in this mode: the profile spares the coverage run, not the mutant test runs, which build against the module dependencies. A relative path resolves against the directory Gremlins was invoked from rather than the module root, since that is where the caller wrote the file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/blob/main/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Tests cover the reuse path (including that the test suite is *not* re-run, only `go mod download`), and each rejection: elapsed unset, unparseable, non-positive; profile missing or unparseable. `go test ./...` and `go vet ./...` are clean. As #290 notes, `make all` has pre-existing lint failures from the unpinned `golangci-lint@latest`, unrelated to this change.

Both new flags are registered in the existing `cmd/unleash_test.go` flag table, documented under `docs/docs/usage/commands/unleash/`, and added to `docs/docs/schema/configuration.json`.
