### PR TITLE
fix(diff): express the diff in the same paths as the mutant positions

### DIFF
--- a/cmd/unleash.go
+++ b/cmd/unleash.go
@@ -159,7 +159,7 @@ func cleanUp(wd string) {
 }
 
 func run(ctx context.Context, mod gomodule.GoModule, workDir string) (report.Results, error) {
-	fDiff, err := diff.New()
+	fDiff, err := diff.New(mod.CallingDir)
 	if err != nil {
 		return report.Results{}, err
 	}

--- a/internal/diff/parse.go
+++ b/internal/diff/parse.go
@@ -11,18 +11,45 @@ import (
 	"github.com/go-gremlins/gremlins/internal/log"
 )
 
-// New creates a new Diff by parsing git diff output using the default command executor.
-func New() (Diff, error) {
-	return NewWithCmd(exec.Command)
+// New creates a new Diff by parsing git diff output using the default
+// command executor.
+//
+// target is the directory Gremlins was pointed at, relative to the
+// directory it is running in — "." for a whole module, "internal/api"
+// for a scoped run. It decides which paths the diff is expressed in;
+// see NewWithCmd.
+func New(target string) (Diff, error) {
+	return NewWithCmd(exec.Command, target)
 }
 
 type execCmd interface {
 	CombinedOutput() ([]byte, error)
 }
 
-// NewWithCmd creates a new Diff by parsing git diff output using a custom command executor.
-// This is useful for testing.
-func NewWithCmd[T execCmd](cmdContext func(name string, args ...string) T) (Diff, error) {
+// NewWithCmd creates a new Diff by parsing git diff output using a
+// custom command executor. This is useful for testing.
+//
+// The diff has to be expressed in the same paths as the mutant
+// positions it will be compared against, and those are relative to
+// whatever directory Gremlins was pointed at: a run over "." reports
+// "internal/api/file.go", a run over "internal/api" reports "file.go".
+// git, left alone, reports paths relative to the REPOSITORY root — so
+// the two agree only when the module is the repository root and the
+// target is ".".
+//
+// Everywhere else the lookup in Diff.IsChanged misses on every file,
+// and the failure is silent in the direction that matters: every mutant
+// comes back SKIPPED, the run finds nothing on the changed lines, and a
+// --diff gate reports success having tested nothing. Measured against a
+// Go module one directory below its repository root: 72 mutants, 72
+// SKIPPED, including the line the diff had just changed.
+//
+// `git -C <target> diff --relative` fixes both halves at once. -C makes
+// git run in the target directory and --relative makes it emit paths
+// relative to that directory, which is exactly what the positions are
+// relative to; and --relative also drops files outside the target,
+// which is what a scoped run wants anyway.
+func NewWithCmd[T execCmd](cmdContext func(name string, args ...string) T, target string) (Diff, error) {
 	diffRef := configuration.Get[string](configuration.UnleashDiffRef)
 	if diffRef == "" {
 		return nil, nil
@@ -30,7 +57,25 @@ func NewWithCmd[T execCmd](cmdContext func(name string, args ...string) T) (Diff
 
 	log.Infoln("Gathering files diff...")
 
-	cmd := cmdContext("git", "diff", "--merge-base", diffRef)
+	// --relative, because gremlins reports a mutant's position relative
+	// to the module it is mutating while git reports a diff relative to
+	// the repository root. Those coincide only when the module IS the
+	// repository root. For a module in a subdirectory — a monorepo, a
+	// Go workspace — every path in the diff carries a prefix the mutant
+	// positions do not have, so the lookup in Diff.IsChanged misses on
+	// every file.
+	//
+	// The failure is silent and it fails GREEN in the sense that
+	// matters: every mutant is reported SKIPPED, the run finds nothing
+	// on the changed lines, and a --diff gate passes having tested
+	// nothing. Measured against a backend module one directory below
+	// its repository root: 72 mutants, 72 SKIPPED, including the line
+	// the diff had just changed.
+	//
+	// --relative makes git emit paths relative to the working directory
+	// instead, which is the directory gremlins was invoked in and the
+	// one its positions are relative to.
+	cmd := cmdContext("git", "-C", target, "diff", "--relative", "--merge-base", diffRef)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/diff/parse_test.go
+++ b/internal/diff/parse_test.go
@@ -14,7 +14,7 @@ func TestNewWithCmd(t *testing.T) {
 	t.Run("must return nil on empty flag", func(t *testing.T) {
 		m := &mock{}
 
-		d, err := NewWithCmd(m.call)
+		d, err := NewWithCmd(m.call, ".")
 
 		if d != nil && err != nil {
 			t.Fatal("incorrect result")
@@ -28,7 +28,7 @@ func TestNewWithCmd(t *testing.T) {
 			outputErr: errors.New("test"),
 		}
 
-		_, err := NewWithCmd(m.call)
+		_, err := NewWithCmd(m.call, ".")
 		if err == nil {
 			t.Error("must return error")
 		}
@@ -37,7 +37,12 @@ func TestNewWithCmd(t *testing.T) {
 			t.Fatal("cmd not called")
 		}
 
-		expectedArgs := []string{"diff", "--merge-base", "test"}
+		// --relative is load-bearing, not cosmetic: without it git
+		// reports paths relative to the repository root while gremlins
+		// reports mutant positions relative to the module, so for a
+		// module in a subdirectory every lookup in Diff.IsChanged
+		// misses and every mutant is SKIPPED. That reads as a pass.
+		expectedArgs := []string{"-C", ".", "diff", "--relative", "--merge-base", "test"}
 
 		if m.callName != "git" || !reflect.DeepEqual(m.callArgs, expectedArgs) {
 			t.Log("name", m.callName)
@@ -53,7 +58,7 @@ func TestNewWithCmd(t *testing.T) {
 			output: []byte(testErrDiff),
 		}
 
-		_, err := NewWithCmd(m.call)
+		_, err := NewWithCmd(m.call, ".")
 		if err == nil {
 			t.Error("must return error")
 		}
@@ -70,7 +75,7 @@ func TestNewWithCmd(t *testing.T) {
 			"test/test": {{StartLine: 44, EndLine: 44}},
 		}
 
-		result, err := NewWithCmd(m.call)
+		result, err := NewWithCmd(m.call, ".")
 
 		if err != nil || !reflect.DeepEqual(result, expected) {
 			t.Log("err", err)


### PR DESCRIPTION
`--diff` and a directory argument are both documented, first-class features of `unleash`, with nothing saying they are exclusive. Combined, they currently produce a **silent false pass**.

## The problem

Mutant positions are relative to the directory Gremlins was pointed at — a run over `.` reports `internal/api/file.go`, a run over `internal/api` reports `file.go`. `git diff`, left alone, reports paths relative to the **repository root**. The two agree only when the module is the repository root *and* the target is `.`.

Everywhere else — a module in a subdirectory, a monorepo, a Go workspace — every lookup in `Diff.IsChanged` misses, so every mutant comes back `SKIPPED`, the run finds nothing on the changed lines, and the gate reports success having tested nothing.

Measured against a Go module one directory below its repository root: **72 mutants, 72 SKIPPED**, including the line the diff had just changed.

## The fix

`git -C <target> diff --relative` repairs both halves at once. `-C` runs git in the target directory and `--relative` emits paths relative to it — which is what the positions are relative to. `--relative` additionally drops files outside the target, which is what a scoped run wants anyway.

The target comes from `mod.CallingDir`. For a module at the repository root with target `.`, the flags are a no-op, so the common case is unaffected.

## Verified

After the change, on a module one directory below its repo root:

- scoped run over the package holding the changed file → **2 mutants found and killed**, 50 skipped
- scoped run over a package holding no changed file → **0 mutants**, rather than skipping every mutant in it
- whole-module run → the changed line's mutants found and killed, 362 skipped

The existing `TestNewWithCmd` argument assertion is updated, since the invocation is part of the contract: the flag is load-bearing, not cosmetic.