### PR TITLE
engine: match diff paths for package-pattern subdirectories

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -192,11 +192,24 @@ func (mu *Engine) mutationStatus(pos token.Position) mutator.Status {
 		status = mutator.Runnable
 	}
 
-	if !mu.codeData.Diff.IsChanged(pos) {
+	diffPos := pos
+	diffPos.Filename = joinCallingDir(mu.module.CallingDir, pos.Filename)
+	if !mu.codeData.Diff.IsChanged(diffPos) {
 		status = mutator.Skipped
 	}
 
 	return status
+}
+
+// joinCallingDir returns the repo-root-relative path of a file found while
+// walking the CallingDir, so it can be looked up in the diff which is keyed
+// by repo-root-relative paths from git.
+func joinCallingDir(callingDir, filename string) string {
+	if callingDir == "" || callingDir == "." {
+		return filename
+	}
+
+	return filepath.ToSlash(filepath.Join(callingDir, filename))
 }
 
 func (mu *Engine) executeTests(ctx context.Context) report.Results {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -649,6 +649,81 @@ func TestSkipNotDiffMutants(t *testing.T) {
 	}
 }
 
+func TestDiffWithSubdirCallingDir(t *testing.T) {
+	t.Parallel()
+	f, _ := os.Open("testdata/fixtures/geq_go")
+	file, _ := io.ReadAll(f)
+	_ = f.Close()
+
+	const fileName = "file.go"
+
+	testCases := []struct {
+		name        string
+		callingDir  string
+		diff        diff.Diff
+		wantSkipped bool
+	}{
+		{
+			name:       "root-relative diff matches subdir walk",
+			callingDir: "internal/somepkg",
+			diff: diff.Diff{
+				"internal/somepkg/" + fileName: {{StartLine: 1, EndLine: 9}},
+			},
+			wantSkipped: false,
+		},
+		{
+			name:       "diff in another dir stays skipped",
+			callingDir: "internal/somepkg",
+			diff: diff.Diff{
+				"internal/other/" + fileName: {{StartLine: 1, EndLine: 9}},
+			},
+			wantSkipped: true,
+		},
+		{
+			name:       "root calling dir still matches",
+			callingDir: ".",
+			diff: diff.Diff{
+				fileName: {{StartLine: 1, EndLine: 9}},
+			},
+			wantSkipped: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sys := fstest.MapFS{
+				fileName: {Data: file},
+			}
+			mod := gomodule.GoModule{
+				Name:       expectedModule,
+				Root:       ".",
+				CallingDir: tc.callingDir,
+			}
+			viperSet(map[string]any{configuration.UnleashDryRunKey: true})
+			defer viperReset()
+
+			codeData := engine.CodeData{Diff: tc.diff}
+			mut := engine.New(mod, codeData, newJobDealerStub(t), engine.WithDirFs(sys))
+			res := mut.Run(context.Background())
+
+			if got := res.Mutants; len(got) == 0 {
+				t.Fatalf("should receive mutants")
+			}
+
+			for _, mutant := range res.Mutants {
+				if tc.wantSkipped && mutant.Status() != mutator.Skipped {
+					t.Errorf("expected skipped mutant, got %v", mutant.Status())
+				}
+				if !tc.wantSkipped && mutant.Status() == mutator.Skipped {
+					t.Errorf("expected mutant not to be skipped")
+				}
+			}
+		})
+	}
+}
+
 func TestStopsOnCancel(t *testing.T) {
 	mapFS, mod, c := loadFixture(defaultFixture, ".")
 	defer c()

--- a/internal/gomodule/gomodule.go
+++ b/internal/gomodule/gomodule.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // GoModule represents the current execution context in Gremlins.
@@ -47,12 +48,31 @@ func Init(path string) (GoModule, error) {
 		return GoModule{}, err
 	}
 	path, _ = filepath.Rel(root, path)
+	path = sanitizeCallingDir(path)
 
 	return GoModule{
 		Name:       mod,
 		Root:       root,
 		CallingDir: path,
 	}, nil
+}
+
+// sanitizeCallingDir normalizes the CallingDir to a clean directory path.
+// It strips Go package-pattern suffixes (e.g. "pkg/..." becomes "pkg") so
+// that downstream consumers (DirFS, coverage, diff lookup, workdir) receive
+// a real directory path.
+func sanitizeCallingDir(dir string) string {
+	dir = filepath.Clean(dir)
+	dir = strings.TrimSuffix(dir, string(filepath.Separator)+"...")
+	if dir == "..." {
+		dir = "."
+	}
+	dir = filepath.Clean(dir)
+	if dir == "" {
+		return "."
+	}
+
+	return dir
 }
 
 func modPkg(path string) (string, string, error) {

--- a/internal/gomodule/gomodule_test.go
+++ b/internal/gomodule/gomodule_test.go
@@ -81,3 +81,64 @@ func TestDetectsModule(t *testing.T) {
 		}
 	})
 }
+
+func TestInitSanitizesCallingDir(t *testing.T) {
+	const modName = "example.com"
+	rootDir := t.TempDir()
+	pkgDir := filepath.Join("internal", "somepkg")
+	absPkgDir := filepath.Join(rootDir, pkgDir)
+	if err := os.MkdirAll(absPkgDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "go.mod"), []byte("module "+modName), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "clean subdir",
+			path: absPkgDir,
+			want: pkgDir,
+		},
+		{
+			name: "subdir with package pattern",
+			path: absPkgDir + string(filepath.Separator) + "...",
+			want: pkgDir,
+		},
+		{
+			name: "nested pattern is stripped",
+			path: filepath.Join(rootDir, "internal", "somepkg", "..."),
+			want: pkgDir,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mod, err := gomodule.Init(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mod.CallingDir != tc.want {
+				t.Errorf("expected CallingDir to be %q, got %q", tc.want, mod.CallingDir)
+			}
+		})
+	}
+
+	t.Run("name ending with dots is preserved", func(t *testing.T) {
+		dotDir := filepath.Join(rootDir, "foo...")
+		if err := os.MkdirAll(dotDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		mod, err := gomodule.Init(dotDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mod.CallingDir != "foo..." {
+			t.Errorf("expected CallingDir to be %q, got %q", "foo...", mod.CallingDir)
+		}
+	})
+}


### PR DESCRIPTION
## Proposed changes

Fixes #278.

`gremlins unleash --diff <ref>` incorrectly marked changed mutants as `SKIPPED` when a subdirectory or trailing `/...` package pattern was supplied. Two path bases disagreed:

1. Git diff keys are repository-root-relative, while files discovered below `CallingDir` are relative to that directory. The engine now prefixes mutation positions with `CallingDir` before the diff lookup, while keeping `diff.Diff` repository-root-relative.
2. A trailing `/...` package pattern was stored verbatim in `CallingDir`, even though downstream filesystem, coverage, workdir, and package-name operations require a real directory. Module initialization now strips that suffix.

Regression tests cover matching and non-matching subdirectory diffs, root invocation, clean subdirectories, trailing package patterns, and directory names that merely end in dots.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/go-gremlins/gremlins/docs/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes (`make all`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

Documentation and downstream changes are not applicable for this focused bug fix.

## Further comments

### Verification

- `go build ./...`, `go test ./...`, `go vet ./...`, and `go test -race ./...` pass on the final code.
- Focused package tests pass for `internal/gomodule`, `internal/diff`, and `internal/engine`.
- `TestInitSanitizesCallingDir` passes all four subtests. `TestDiffWithSubdirCallingDir` passes all three subtests alongside the existing `TestSkipNotDiffMutants`.
- Reverting only `engine.go` makes the root-relative subdirectory-diff regression test fail. Reverting only `gomodule.go` makes both trailing `/...` cases fail.
- `make lint` reports the same 27 pre-existing `goconst` findings as the base commit and no new findings.
- End-to-end testing with a scratch module and a real `git diff --merge-base` reproduces two `SKIPPED` mutants before the fix. The fixed build reports both as `RUNNABLE` for a subdirectory, a subdirectory `/...` pattern, and the root invocation.

### Design notes

The implementation keeps `diff.Diff` repository-root-relative instead of coupling diff parsing to module discovery or changing the path basis used by coverage, exclusion, and execution.

PR #300 addresses a related current-working-directory case by asking Git for relative paths. Because that approach and this one choose different path bases, they should be reconciled if both changes proceed; this PR specifically covers the explicit subdirectory-argument and package-pattern cases from #278.
